### PR TITLE
Issue #32: Create Dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Ignore everything
+*
+
+# Allow source code
+!Makefile
+!src/**
+

--- a/pkg/docker/Dockerfile_Debian
+++ b/pkg/docker/Dockerfile_Debian
@@ -1,0 +1,36 @@
+#FROM ubuntu:rolling
+FROM debian:buster-slim as build
+
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        make \
+        gcc \
+        git \
+        libevent-dev \
+        libjpeg62-turbo-dev \
+        uuid-dev \
+        libbsd-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build/ustreamer/
+COPY . .
+RUN make
+
+FROM debian:buster-slim as run
+
+RUN apt-get update && \
+    apt-get install -y \
+        ca-certificates \
+        libevent-2.1 \
+        libevent-pthreads-2.1-6 \
+        libjpeg62-turbo \
+        uuid \
+        libbsd0 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /ustreamer
+COPY --from=build /build/ustreamer/ustreamer .
+#ENV LD_LIBRARY_PATH=/opt/vc/lib
+EXPOSE 8080
+ENTRYPOINT [ "./ustreamer", "--host=0.0.0.0", "--slowdown"]

--- a/pkg/docker/Dockerfile_NativeRaspberry
+++ b/pkg/docker/Dockerfile_NativeRaspberry
@@ -1,0 +1,32 @@
+FROM balenalib/raspberrypi3-debian:build as build
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gcc \
+        libjpeg8-dev \
+        libbsd-dev \
+        libraspberrypi-dev \
+        wiringpi \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build/ustreamer/
+COPY . .
+RUN make WITH_OMX=1 WITH_GPIO=1
+
+FROM balenalib/raspberrypi3-debian:run as RUN
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libevent-2.1 \
+        libevent-pthreads-2.1-6 \
+        libjpeg8 \
+        uuid \
+        libbsd0 \
+        wiringpi \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /ustreamer
+COPY --from=build /build/ustreamer/ustreamer .
+
+EXPOSE 8080
+ENTRYPOINT [ "./ustreamer", "--host=0.0.0.0"]

--- a/pkg/docker/Dockerfile_RaspberryCrossbuild
+++ b/pkg/docker/Dockerfile_RaspberryCrossbuild
@@ -1,0 +1,39 @@
+FROM balenalib/raspberrypi3-debian:build as build
+
+RUN [ "cross-build-start" ]
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gcc \
+        libjpeg8-dev \
+        libbsd-dev \
+        libraspberrypi-dev \
+        wiringpi \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build/ustreamer/
+COPY . .
+RUN make WITH_OMX=1 WITH_GPIO=1
+RUN [ "cross-build-end" ]
+
+FROM balenalib/raspberrypi3-debian:run as RUN
+
+RUN [ "cross-build-start" ]
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libevent-2.1 \
+        libevent-pthreads-2.1-6 \
+        libjpeg8 \
+        uuid \
+        libbsd0 \
+        wiringpi \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN [ "cross-build-end" ]
+
+WORKDIR /ustreamer
+COPY --from=build /build/ustreamer/ustreamer .
+
+EXPOSE 8080
+ENTRYPOINT [ "./ustreamer", "--host=0.0.0.0"]


### PR DESCRIPTION
This is a proposal to address the feature "Official Docker Images". This PR contains three Dockerfiles for three different use-cases:

- Dockerfile_NativeRaspberry to build an image on an arm CPU
- Dockerfile_RaspberryCrossbuild to build an ARM image on an x86 CPU
- Dockerfile_Debian to build x86 image on x86 CPU

I used debian out of convenience. I tried building an arm image using alpine, but got terrible performance out of it.
To build an image you can run the following command from the root directory:
`sudo docker build --file pkg/docker/Dockerfile_debian .`

I've only tested these builds on an ARM CPU so far, but the images from [beholder-rpa/ustreamer-docker](https://github.com/beholder-rpa/ustreamer-docker) seem to be building just fine using a very similar setup.