### PR TITLE
add debian:buster-slim based docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,6 @@
 *
 
 # Allow source code
+!.github/workflows/*.sh
 !Makefile
 !src/**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,70 @@
+name: Build
+on:
+  - push
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup environment
+        run: sudo ./.github/workflows/setup-environment.sh
+      - name: Build
+        run: |
+          set -euxo pipefail
+          # create a local buildx builder.
+          DOCKER_CLI_EXPERIMENTAL=enabled \
+            docker buildx create \
+              --name local \
+              --driver docker-container \
+              --driver-opt network=host \
+              --use
+          DOCKER_CLI_EXPERIMENTAL=enabled \
+            docker buildx ls
+          # build the images for the given platforms.
+          # NB we cannot enable linux/arm64 because OMX does not seem to build
+          #    in 64-bit mode. the build with fail with:
+          #       == CFLAGS  = -O3 -c -std=c11 -Wall -Wextra -D_GNU_SOURCE -DWITH_OMX -DOMX_SKIP64BIT -I/opt/vc/include -DWITH_GPIO -DWITH_PTHREAD_NP -DWITH_SETPROCTITLE
+          #       == LDFLAGS = 
+          #       /usr/bin/ld: cannot find -lopenmaxil
+          DOCKER_CLI_EXPERIMENTAL=enabled \
+            docker buildx build \
+              --file pkg/docker/Dockerfile \
+              --tag localhost:5000/ustreamer \
+              --output type=registry \
+              --platform linux/amd64,linux/arm/v7 \
+              --progress plain \
+              .
+      - name: Show image manifest
+        run: |
+          set -euxo pipefail
+          http get http://localhost:5000/v2/_catalog
+          http get http://localhost:5000/v2/ustreamer/tags/list
+          http get \
+            http://localhost:5000/v2/ustreamer/manifests/latest \
+            Accept:application/vnd.docker.distribution.manifest.list.v2+json
+          skopeo inspect --raw docker://localhost:5000/ustreamer
+      - name: Use native container
+        run: |
+          set -euxo pipefail
+          docker rmi -f localhost:5000/ustreamer
+          docker run --rm -t localhost:5000/ustreamer --version
+          docker run --rm -t localhost:5000/ustreamer --features
+      - name: Use linux/arm/v7 emulated container
+        run: |
+          set -euxo pipefail
+          docker rmi -f localhost:5000/ustreamer
+          docker run --platform linux/arm/v7 --rm -t localhost:5000/ustreamer --version
+          docker run --platform linux/arm/v7 --rm -t localhost:5000/ustreamer --features
+      - name: Publish to Docker Hub
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+        run: |
+          image_name='ustreamer'
+          image_tag="$(echo "$GITHUB_REF" | sed -E 's,^refs/tags/,,')"
+          skopeo copy --all \
+            --dest-creds "$DOCKER_HUB_USER:$DOCKER_HUB_ACCESS_TOKEN" \
+            docker://localhost:5000/ustreamer \
+            docker://docker.io/$DOCKER_HUB_USER/$image_name:$image_tag

--- a/.github/workflows/install-build-dependencies.sh
+++ b/.github/workflows/install-build-dependencies.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euxo pipefail
+
+# add the raspberrypi repository.
+apt-get update
+apt-get install -y --no-install-recommends gpg gpg-agent dirmngr
+gpg --keyserver keys.gnupg.net --recv-key 82B129927FA3303E
+gpg --armor --export 82B129927FA3303E | apt-key add -
+echo 'deb http://archive.raspberrypi.org/debian/ buster main' >/etc/apt/sources.list.d/raspi.list
+apt-get update
+
+# install build dependencies.
+apt-get install -y --no-install-recommends \
+    gcc \
+    libbsd-dev \
+    libevent-dev \
+    libgpiod-dev \
+    libjpeg62-turbo-dev \
+    make \
+    uuid-dev
+if [[ "$TARGETPLATFORM" == linux/arm* ]]; then
+    apt-get install -y --no-install-recommends \
+        libraspberrypi-dev
+    WITH_OMX='1'
+else
+    WITH_OMX='0'
+fi
+
+# save the build command line.
+cat >build.sh <<EOF
+#!/bin/bash
+set -euxo pipefail
+make -j5 WITH_OMX=$WITH_OMX WITH_GPIO=1
+EOF
+chmod +x build.sh
+
+# clean up.
+rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/install-runtime-dependencies.sh
+++ b/.github/workflows/install-runtime-dependencies.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euxo pipefail
+
+# add the raspberrypi repository.
+apt-get update
+apt-get install -y --no-install-recommends gpg gpg-agent dirmngr
+gpg --keyserver keys.gnupg.net --recv-key 82B129927FA3303E
+gpg --armor --export 82B129927FA3303E | apt-key add -
+echo 'deb http://archive.raspberrypi.org/debian/ buster main' >/etc/apt/sources.list.d/raspi.list
+apt-get update
+
+# install runtime dependencies.
+apt-get install -y --no-install-recommends \
+    libbsd0 \
+    libevent-2.1 \
+    libevent-pthreads-2.1-6 \
+    libgpiod2 \
+    libjpeg62-turbo \
+    libuuid1
+if [[ "$TARGETPLATFORM" == linux/arm* ]]; then
+    apt-get install -y --no-install-recommends \
+        libraspberrypi0
+fi
+
+# clean up.
+apt-get remove -y --purge gpg gpg-agent dirmngr
+apt-get autoremove -y --purge
+apt-get clean
+rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/setup-environment.sh
+++ b/.github/workflows/setup-environment.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euxo pipefail
+
+# configure skopeo.
+install -d -m 755 /etc/containers/registries.conf.d
+cat >/etc/containers/registries.conf.d/localhost-5000.conf <<'EOF'
+[[registry]]
+location = 'localhost:5000'
+insecure = true
+EOF
+
+# configure docker.
+systemctl stop docker
+cat >/etc/docker/daemon.json <<'EOF'
+{
+    "experimental": true,
+    "debug": false,
+    "log-driver": "journald",
+    "labels": [
+        "os=linux"
+    ],
+    "hosts": [
+        "unix://"
+    ]
+}
+EOF
+
+# start docker without any command line flags as its entirely configured from daemon.json.
+install -d /etc/systemd/system/docker.service.d
+cat >/etc/systemd/system/docker.service.d/override.conf <<'EOF'
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd
+EOF
+
+# start docker.
+systemctl daemon-reload
+systemctl start docker
+
+# show docker information.
+docker info
+
+# install dependencies.
+apt-get install -y qemu-user-static httpie
+
+# start a local registry.
+docker run -d --restart=unless-stopped --name registry -p 5000:5000 registry:2.7.1
+docker exec registry registry --version

--- a/README.md
+++ b/README.md
@@ -52,6 +52,45 @@ $ ./ustreamer --help
 AUR has a package for Arch Linux: https://aur.archlinux.org/packages/ustreamer. It should compile automatically with OpenMAX IL on Raspberry Pi, if the corresponding headers are present in ```/opt/vc/include```.  
 FreeBSD port: https://www.freshports.org/multimedia/ustreamer.
 
+## Building (Docker on Raspbian on Raspberry Pi 4)
+
+Build ustreamer:
+
+```bash
+docker build --file pkg/docker/Dockerfile --tag ustreamer .
+```
+
+Set the hdmi-to-csi bridge EDID:
+
+```bash
+wget -qO tc358743-edid.hex https://raw.githubusercontent.com/pikvm/kvmd/master/configs/kvmd/tc358743-edid.hex
+v4l2-ctl --device /dev/video0 --set-edid file=tc358743-edid.hex --fix-edid-checksums
+```
+
+Start ustreamer in foreground:
+
+```bash
+docker run --rm \
+  --device /dev/video0 \
+  --device /dev/vchiq \
+  -p 8080:8080 \
+  ustreamer \
+  --device=/dev/video0 \
+  --persistent \
+  --dv-timings \
+  --format=uyvy \
+  --encoder=omx \
+  --workers=$(nproc) \
+  --quality=85 \
+  --desired-fps=30 \
+  --drop-same-frames=30 \
+  --slowdown \
+  --host=0.0.0.0 \
+  --port=8080
+```
+
+Then access the web interface at port 8080 (e.g. http://raspberrypi.local:8080).
+
 -----
 # Usage
 Without arguments, ```ustreamer``` will try to open ```/dev/video0``` with 640x480 resolution and start streaming on  ```http://127.0.0.1:8080```. You can override this behavior using parameters ```--device```, ```--host``` and ```--port```. For example, to stream to the world, run:

--- a/pkg/docker/Dockerfile
+++ b/pkg/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:buster-slim as build
+ARG TARGETPLATFORM
+WORKDIR /build/ustreamer
+COPY .github/workflows/install-build-dependencies.sh .
+RUN ./install-build-dependencies.sh
+COPY . .
+RUN ./build.sh
+
+FROM debian:buster-slim
+ARG TARGETPLATFORM
+WORKDIR /ustreamer
+COPY .github/workflows/install-runtime-dependencies.sh .
+RUN ./install-runtime-dependencies.sh && rm install-runtime-dependencies.sh
+COPY --from=build /build/ustreamer/ustreamer .
+EXPOSE 8080
+ENTRYPOINT ["./ustreamer"]


### PR DESCRIPTION
This add a github actions workflow to build the multi-platform container image and publish it to docker hub (only when there is a `v` prefixed tag associated with the commit).

In order to publish to docker hub a couple of secrets need to be created in this repository settings:

1. `DOCKER_HUB_USER`
2. `DOCKER_HUB_ACCESS_TOKEN`: this can be created from your docker hub security page inside you account.

It probably would also be nice to include a badge in the readme, something alike:

[![Docker pulls](https://img.shields.io/docker/pulls/ruilopes/ustreamer?logo=docker)](https://hub.docker.com/repository/docker/ruilopes/ustreamer)

Also it might be useful to modify the README to mention the docker hub image?

Also maybe we should include the edid file and load it everytime the container is started? this would mean that the v4l2-ctl tool (and dependencies) would have to be included in the container image. Hummm, but this makes the assumption that the user is using the hdmi-to-csi bridge, so maybe not such a great idea.

This should close #32.