### PR TITLE
V4L changes to abstract capture handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,13 +46,13 @@ endef
 
 
 ifneq ($(call optbool,$(WITH_OMX)),)
-_USTR_LIBS += -lbcm_host -lvcos -lvcsm -lopenmaxil -lmmal -lmmal_core -lmmal_util -lmmal_vc_client -lmmal_components -L$(RPI_VC_LIBS)
+_USTR_LIBS += -lbcm_host -lvcos -lvcsm -lmmal -lmmal_core -lmmal_util -lmmal_vc_client -lmmal_components -L$(RPI_VC_LIBS)
 override CFLAGS += -DWITH_OMX -DOMX_SKIP64BIT -I$(RPI_VC_HEADERS)
+endif
+
 _USTR_SRCS += $(shell ls \
-	src/ustreamer/encoders/omx/*.c \
 	src/ustreamer/h264/*.c \
 )
-endif
 
 
 ifneq ($(call optbool,$(WITH_GPIO)),)

--- a/src/libs/unjpeg.c
+++ b/src/libs/unjpeg.c
@@ -52,7 +52,7 @@ int unjpeg(const frame_s *src, frame_s *dest, bool decode) {
 	}
 
 	jpeg_mem_src(&jpeg, src->data, src->used);
-	jpeg_read_header(&jpeg, TRUE);
+	jpeg_read_header(&jpeg, false);
 	jpeg.out_color_space = JCS_RGB;
 
 	jpeg_start_decompress(&jpeg);

--- a/src/ustreamer/h264/encoder.c
+++ b/src/ustreamer/h264/encoder.c
@@ -149,6 +149,13 @@ int h264_encoder_prepare(h264_encoder_s *enc, const frame_s *frame,
           mp->pixelformat, mp->plane_fmt[0].bytesperline,
           mp->plane_fmt[0].sizeimage);
 
+  mp->width = frame->width;
+  mp->height = frame->height;
+  ret = ioctl(enc->fd, VIDIOC_S_FMT, &fm);
+  fprintf(stderr, "Capture set: %d %d (res: %ux%u) %u %u %u\n", ret, errno,
+          mp->height, mp->width, mp->plane_fmt[0].bytesperline,
+          mp->plane_fmt[0].sizeimage, mp->pixelformat);
+
   struct v4l2_streamparm stream;
   memset(&stream, 0, sizeof(stream));
   stream.type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;

--- a/src/ustreamer/h264/encoder.h
+++ b/src/ustreamer/h264/encoder.h
@@ -28,37 +28,32 @@
 
 #include <linux/videodev2.h>
 
-#include <interface/mmal/mmal.h>
-#include <interface/mmal/mmal_format.h>
-#include <interface/mmal/util/mmal_default_components.h>
-#include <interface/mmal/util/mmal_component_wrapper.h>
-#include <interface/mmal/util/mmal_util_params.h>
-#include <interface/vcsm/user-vcsm.h>
-
 #include "../../libs/tools.h"
 #include "../../libs/logging.h"
 #include "../../libs/frame.h"
 
 
 typedef struct {
-	unsigned bitrate; // Kbit-per-sec
-	unsigned gop; // Interval between keyframes
-	unsigned fps;
+  void *start;
+  size_t length;
+  struct v4l2_buffer inner;
+  struct v4l2_plane planes;
+} buffer;
 
-	MMAL_WRAPPER_T		*wrapper;
-	MMAL_PORT_T			*input_port;
-	MMAL_PORT_T			*output_port;
-	VCOS_SEMAPHORE_T	handler_sem;
-	bool				i_handler_sem;
+typedef struct {
+	int fd;
+	buffer* output;
+	int output_len;
+	buffer capture;
 
-	int last_online;
+  uint32_t width;
+  uint32_t height;
 
-	unsigned	width;
-	unsigned	height;
-	unsigned	format;
-	unsigned	stride;
-	bool		zero_copy;
-	bool		ready;
+  bool prepared;
+  double start_ts;
+
+  int last_online;
+  long frame;
 } h264_encoder_s;
 
 

--- a/src/ustreamer/h264/stream.c
+++ b/src/ustreamer/h264/stream.c
@@ -80,10 +80,8 @@ void h264_stream_process(h264_stream_s *h264, const frame_s *frame, int vcsm_han
 		h264_encoder_prepare(h264->enc, frame, zero_copy);
 	}
 
-	if (h264->enc->ready) {
-		if (h264_encoder_compress(h264->enc, frame, vcsm_handle, h264->dest, force_key) == 0) {
-			online = !memsink_server_put(h264->sink, h264->dest);
-		}
+	if (h264_encoder_compress(h264->enc, frame, vcsm_handle, h264->dest, force_key) == 0) {
+		online = !memsink_server_put(h264->sink, h264->dest);
 	}
 
 	atomic_store(&h264->online, online);

--- a/src/ustreamer/main.c
+++ b/src/ustreamer/main.c
@@ -37,7 +37,6 @@
 #include <pthread.h>
 #ifdef WITH_OMX
 #	include <bcm_host.h>
-#	include <IL/OMX_Core.h>
 #endif
 
 #include "../libs/tools.h"
@@ -136,12 +135,6 @@ int main(int argc, char *argv[]) {
 			bcm_host_init();
 			i_bcm_host = true;
 		}
-		if (enc->type == ENCODER_TYPE_OMX) {
-			if ((omx_error = OMX_Init()) != OMX_ErrorNone) {
-				LOG_ERROR_OMX(omx_error, "Can't initialize OMX Core; forced CPU encoder");
-				enc->type = ENCODER_TYPE_CPU;
-			}
-		}
 #		endif
 
 #		ifdef WITH_GPIO
@@ -181,9 +174,6 @@ int main(int argc, char *argv[]) {
 	options_destroy(options);
 
 #	ifdef WITH_OMX
-	if (omx_error == OMX_ErrorNone) {
-		OMX_Deinit();
-	}
 	if (i_bcm_host) {
 		bcm_host_deinit();
 	}

--- a/src/ustreamer/options.c
+++ b/src/ustreamer/options.c
@@ -88,11 +88,9 @@ enum _OPT_VALUES {
 		_O_##_prefix##_RM, \
 		_O_##_prefix##_TIMEOUT,
 	ADD_SINK(SINK)
-#	ifdef WITH_OMX
 	ADD_SINK(H264_SINK)
 	_O_H264_BITRATE,
 	_O_H264_GOP,
-#	endif
 #	undef ADD_SINK
 
 #	ifdef WITH_GPIO
@@ -179,11 +177,9 @@ static const struct option _LONG_OPTS[] = {
 		{_opt "sink-rm",		no_argument,		NULL,	_O_##_prefix##_RM}, \
 		{_opt "sink-timeout",	required_argument,	NULL,	_O_##_prefix##_TIMEOUT},
 	ADD_SINK("", SINK)
-#	ifdef WITH_OMX
 	ADD_SINK("h264-", H264_SINK)
 	{"h264-bitrate",			required_argument,	NULL,	_O_H264_BITRATE},
 	{"h264-gop",				required_argument,	NULL,	_O_H264_GOP},
-#	endif
 #	undef ADD_SINK
 
 #	ifdef WITH_GPIO
@@ -243,9 +239,7 @@ void options_destroy(options_s *options) {
 			} \
 		}
 	ADD_SINK(sink);
-#	ifdef WITH_OMX
 	ADD_SINK(h264_sink);
-#	endif
 #	undef ADD_SINK
 
 	if (options->blank) {
@@ -336,9 +330,7 @@ int options_parse(options_s *options, device_s *dev, encoder_s *enc, stream_s *s
 		bool _prefix##_rm = false; \
 		unsigned _prefix##_timeout = 1;
 	ADD_SINK(sink);
-#	ifdef WITH_OMX
 	ADD_SINK(h264_sink);
-#	endif
 #	undef ADD_SINK
 
 #	ifdef WITH_SETPROCTITLE
@@ -433,11 +425,9 @@ int options_parse(options_s *options, device_s *dev, encoder_s *enc, stream_s *s
 				case _O_##_up##_RM:			OPT_SET(_lp##_rm, true); \
 				case _O_##_up##_TIMEOUT:	OPT_NUMBER("--" #_opt "sink-timeout", _lp##_timeout, 1, 60, 0);
 			ADD_SINK("", sink, SINK)
-#			ifdef WITH_OMX
 			ADD_SINK("h264-", h264_sink, H264_SINK)
 			case _O_H264_BITRATE:	OPT_NUMBER("--h264-bitrate", stream->h264_bitrate, 100, 16000, 0);
 			case _O_H264_GOP:		OPT_NUMBER("--h264-gop", stream->h264_gop, 0, 60, 0);
-#			endif
 #			undef ADD_SINK
 
 #			ifdef WITH_GPIO
@@ -493,9 +483,7 @@ int options_parse(options_s *options, device_s *dev, encoder_s *enc, stream_s *s
 			stream->_prefix = options->_prefix; \
 		}
 	ADD_SINK("JPEG", sink);
-#	ifdef WITH_OMX
 	ADD_SINK("H264", h264_sink);
-#	endif
 #	undef ADD_SINK
 
 #	ifdef WITH_SETPROCTITLE
@@ -666,11 +654,9 @@ static void _help(FILE *fp, device_s *dev, encoder_s *enc, stream_s *stream, ser
 		SAY("    --" _opt "sink-rm  ──────────── Remove shared memory on stop. Default: disabled.\n"); \
 		SAY("    --" _opt "sink-timeout <sec>  ─ Timeout for lock. Default: 1.\n");
 	ADD_SINK("JPEG", "")
-#	ifdef WITH_OMX
 	ADD_SINK("H264", "h264-")
 	SAY("    --h264-bitrate <kbps>  ───── H264 bitrate in Kbps. Default: %u.\n", stream->h264_bitrate);
 	SAY("    --h264-gop <N>  ──────────── Intarval between keyframes. Default: %u.\n", stream->h264_gop);
-#	endif
 #	undef ADD_SINK
 #	ifdef WITH_GPIO
 	SAY("GPIO options:");

--- a/src/ustreamer/options.h
+++ b/src/ustreamer/options.h
@@ -55,9 +55,7 @@ typedef struct {
 	char		**argv_copy;
 	frame_s		*blank;
 	memsink_s	*sink;
-#	ifdef WITH_OMX
 	memsink_s	*h264_sink;
-#	endif
 } options_s;
 
 

--- a/src/ustreamer/stream.h
+++ b/src/ustreamer/stream.h
@@ -42,9 +42,7 @@
 #include "device.h"
 #include "encoder.h"
 #include "workers.h"
-#ifdef WITH_OMX
 #	include "h264/stream.h"
-#endif
 #ifdef WITH_GPIO
 #	include "gpio/gpio.h"
 #endif
@@ -63,9 +61,7 @@ typedef struct {
 	video_s		*video;
 	long double	last_as_blank_ts;
 
-#	ifdef WITH_OMX
 	h264_stream_s *h264;
-#	endif
 
 	atomic_bool stop;
 } stream_runtime_s;
@@ -81,11 +77,9 @@ typedef struct {
 
 	memsink_s	*sink;
 
-#	ifdef WITH_OMX
 	memsink_s	*h264_sink;
 	unsigned	h264_bitrate;
 	unsigned	h264_gop;
-#	endif
 
 	stream_runtime_s *run;
 } stream_s;


### PR DESCRIPTION
From the description it looks like this may be a good way to further abstract capturing video using the special devices for the hardware encoding/decoding through the v4l APIs. Please check these changes and see if they are an improvement over the older or more hardware-specific routines.