### PR TITLE
Option to rotate image for Raspberry Pi Camera Module

### DIFF
--- a/src/ustreamer/device.c
+++ b/src/ustreamer/device.c
@@ -852,6 +852,7 @@ static void _device_apply_controls(device_s *dev) {
 	CONTROL_AUTO_CID	(V4L2_CID_AUTO_WHITE_BALANCE,	V4L2_CID_WHITE_BALANCE_TEMPERATURE,	white_balance);
 	CONTROL_AUTO_CID	(V4L2_CID_AUTOGAIN,				V4L2_CID_GAIN,						gain);
 	CONTROL_MANUAL_CID	(								V4L2_CID_COLORFX,					color_effect);
+	CONTROL_MANUAL_CID	(								V4L2_CID_ROTATE,	   				rotate);
 	CONTROL_MANUAL_CID	(								V4L2_CID_VFLIP,						flip_vertical);
 	CONTROL_MANUAL_CID	(								V4L2_CID_HFLIP,						flip_horizontal);
 

--- a/src/ustreamer/device.h
+++ b/src/ustreamer/device.h
@@ -122,6 +122,7 @@ typedef struct {
 	control_s white_balance;
 	control_s gain;
 	control_s color_effect;
+	control_s rotate;
 	control_s flip_vertical;
 	control_s flip_horizontal;
 } controls_s;

--- a/src/ustreamer/options.c
+++ b/src/ustreamer/options.c
@@ -72,6 +72,7 @@ enum _OPT_VALUES {
 	_O_WHITE_BALANCE,
 	_O_GAIN,
 	_O_COLOR_EFFECT,
+	_O_ROTATE,
 	_O_FLIP_VERTICAL,
 	_O_FLIP_HORIZONTAL,
 
@@ -158,6 +159,7 @@ static const struct option _LONG_OPTS[] = {
 	{"white-balance",			required_argument,	NULL,	_O_WHITE_BALANCE},
 	{"gain",					required_argument,	NULL,	_O_GAIN},
 	{"color-effect",			required_argument,	NULL,	_O_COLOR_EFFECT},
+	{"rotate",				required_argument,	NULL,	_O_ROTATE},
 	{"flip-vertical",			required_argument,	NULL,	_O_FLIP_VERTICAL},
 	{"flip-horizontal",			required_argument,	NULL,	_O_FLIP_HORIZONTAL},
 
@@ -394,6 +396,7 @@ int options_parse(options_s *options, device_s *dev, encoder_s *enc, stream_s *s
 				OPT_CTL_DEFAULT_NOBREAK(white_balance);
 				OPT_CTL_DEFAULT_NOBREAK(gain);
 				OPT_CTL_DEFAULT_NOBREAK(color_effect);
+				OPT_CTL_DEFAULT_NOBREAK(rotate);
 				OPT_CTL_DEFAULT_NOBREAK(flip_vertical);
 				OPT_CTL_DEFAULT_NOBREAK(flip_horizontal);
 				break;
@@ -407,6 +410,7 @@ int options_parse(options_s *options, device_s *dev, encoder_s *enc, stream_s *s
 			case _O_WHITE_BALANCE:			OPT_CTL_AUTO(white_balance);
 			case _O_GAIN:					OPT_CTL_AUTO(gain);
 			case _O_COLOR_EFFECT:			OPT_CTL_MANUAL(color_effect);
+			case _O_ROTATE:			 	OPT_CTL_MANUAL(rotate);
 			case _O_FLIP_VERTICAL:			OPT_CTL_MANUAL(flip_vertical);
 			case _O_FLIP_HORIZONTAL:		OPT_CTL_MANUAL(flip_horizontal);
 
@@ -637,6 +641,7 @@ static void _help(FILE *fp, device_s *dev, encoder_s *enc, stream_s *stream, ser
 	SAY("    --white-balance <N|auto|default>  ───── Set white balance. Default: no change.\n");
 	SAY("    --gain <N|auto|default>  ────────────── Set gain. Default: no change.\n");
 	SAY("    --color-effect <N|default>  ─────────── Set color effect. Default: no change.\n");
+	SAY("    --rotate <N|default>  ───────────────── Set rotation. Default: no change.\n");
 	SAY("    --flip-vertical <1|0|default>  ──────── Set vertical flip. Default: no change.\n");
 	SAY("    --flip-horizontal <1|0|default>  ────── Set horizontal flip. Default: no change.\n");
 	SAY("    Hint: use v4l2-ctl --list-ctrls-menus to query available controls of the device.\n");


### PR DESCRIPTION
Option to rotate image for Raspberry Pi Camera Module

$v4l2-ctl -l
-->  rotate 0x00980922 (int)    : min=0 max=360 step=90 default=0 value=0 flags=modify-layout



