### PR TITLE
Clarify that dual_final_frames parameter applies to most browsers

### DIFF
--- a/src/ustreamer/data/index.html
+++ b/src/ustreamer/data/index.html
@@ -41,14 +41,16 @@
 				<li>
 					<b>advance_headers=1</b><br>
 					Enable workaround for the Chromium/Blink bug
-					<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=527446">#527446</a>.
+					<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=527446">#527446</a>.<br>
+					This parameter cannot be used in conjunction with <i>dual_final_frames=1</i>.
 				</li>
 				<br>
 				<li>
 					<b>dual_final_frames=1</b><br>
 					Enable workaround for a common web browser bug when using option <i>--drop-same-frames</i>.<br>
 					Without this option, when the frame series is completed, most browsers<br>
-					render the last frame with a delay.
+					render the last frame with a delay.<br>
+					This parameter cannot be used in conjunction with <i>advance_headers=1</i>.
 				</li>
 				<br>
 				<li>

--- a/src/ustreamer/data/index.html
+++ b/src/ustreamer/data/index.html
@@ -46,9 +46,9 @@
 				<br>
 				<li>
 					<b>dual_final_frames=1</b><br>
-					Enable workaround for the Safari/WebKit bug when using option <i>--drop-same-frames</i>.<br>
-					Without this option, when the frame series is completed, WebKit-based browsers<br>
-					renders the last frame with a delay.
+					Enable workaround for a common web browser bug when using option <i>--drop-same-frames</i>.<br>
+					Without this option, when the frame series is completed, most browsers<br>
+					render the last frame with a delay.
 				</li>
 				<br>
 				<li>

--- a/src/ustreamer/data/index_html.c
+++ b/src/ustreamer/data/index_html.c
@@ -66,14 +66,16 @@ const char *const HTML_INDEX_PAGE = " \
 					<li> \
 						<b>advance_headers=1</b><br> \
 						Enable workaround for the Chromium/Blink bug \
-						<a href=\"https://bugs.chromium.org/p/chromium/issues/detail?id=527446\">#527446</a>. \
+						<a href=\"https://bugs.chromium.org/p/chromium/issues/detail?id=527446\">#527446</a>.<br> \
+						This parameter cannot be used in conjunction with <i>dual_final_frames=1</i>. \
 					</li> \
 					<br> \
 					<li> \
 						<b>dual_final_frames=1</b><br> \
 						Enable workaround for a common web browser bug when using option <i>--drop-same-frames</i>.<br> \
 						Without this option, when the frame series is completed, most browsers<br> \
-						render the last frame with a delay. \
+						render the last frame with a delay.<br> \
+						This parameter cannot be used in conjunction with <i>advance_headers=1</i>. \
 					</li> \
 					<br> \
 					<li> \

--- a/src/ustreamer/data/index_html.c
+++ b/src/ustreamer/data/index_html.c
@@ -71,9 +71,9 @@ const char *const HTML_INDEX_PAGE = " \
 					<br> \
 					<li> \
 						<b>dual_final_frames=1</b><br> \
-						Enable workaround for the Safari/WebKit bug when using option <i>--drop-same-frames</i>.<br> \
-						Without this option, when the frame series is completed, WebKit-based browsers<br> \
-						renders the last frame with a delay. \
+						Enable workaround for a common web browser bug when using option <i>--drop-same-frames</i>.<br> \
+						Without this option, when the frame series is completed, most browsers<br> \
+						render the last frame with a delay. \
 					</li> \
 					<br> \
 					<li> \


### PR DESCRIPTION
The current documentation says that this option is specifically for Safari and WebKit-based browsers, but I see this bug on Windows versions of Chrome, Firefox, and Edge.

This change updates the documentation for the dual_final_frames URL parameter to clarify that the workaround applies to many browsers beyond Safari.

## Video demo

To reproduce this, I reduced FPS to 5, so uStreamer was running with the following settings on a TinyPilot Voyager:

```bash
ustreamer \
  --port 8001 \
  --encoder omx \
  --format uyvy \
  --desired-fps 5 \
  --workers 3 \
  --drop-same-frames 30 \
  --persistent \
  --dv-timings
```

I loaded the page in Chrome 93 x64 (Windows) and moved the mouse both before and after applying dual_final_frames.

### With `?advance_headers=1`

https://user-images.githubusercontent.com/7783288/135303689-ff5e04fd-8db9-4ebe-b132-6b5d4344e910.mp4

### With `?advance_headers=1&dual_final_frames=1`

https://user-images.githubusercontent.com/7783288/135303725-0561e652-2f38-4072-b5f3-fd7770aed40a.mp4
