### PR TITLE
Document how to integrate uStreamer with nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ $ ./ustreamer \
 
 You can always view the full list of options with ```ustreamer --help```.
 
+---
+# Integrations
+
+## nginx
+
+When uStreamer is behind an nginx proxy, nginx's buffering behavior introduces latency into the video stream. It's possible to disable nginx's buffering to eliminate the additional latency:
+
+```text
+location /stream {
+  # Disable buffering for uStreamer video stream
+  postpone_output 0;
+  proxy_buffering off;
+  proxy_ignore_headers X-Accel-Buffering;
+
+  proxy_pass http://ustreamer;
+}
+```
+
 -----
 # Raspberry Pi Camera Example
 Example usage for the Raspberry Pi v1 camera:


### PR DESCRIPTION
This change documents a gotcha that can occur when clients deploy uStreamer behind an nginx proxy. By default, nginx buffers responses, which introduces latency into the video stream. Disabling the buffer eliminates this latency.