### PR TITLE
Update libjpeg dependency to libjpeg9

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ If you're going to live-stream from your backyard webcam and need to control it,
 
 -----
 # Building
-You'll need  ```make```, ```gcc```, ```libevent``` with ```pthreads``` support, ```libjpeg8```/```libjpeg-turbo``` and ```libbsd``` (only for Linux).
+You'll need  ```make```, ```gcc```, ```libevent``` with ```pthreads``` support, ```libjpeg9```/```libjpeg-turbo``` and ```libbsd``` (only for Linux).
 
 * Arch: `sudo pacman -S libevent libjpeg-turbo libutil-linux libbsd`.
-* Raspbian: `sudo apt install libevent-dev libjpeg8-dev libbsd-dev`. Add `libraspberrypi-dev` for `WITH_OMX=1` and `libgpiod` for `WITH_GPIO=1`.
+* Raspbian: `sudo apt install libevent-dev libjpeg9-dev libbsd-dev`. Add `libraspberrypi-dev` for `WITH_OMX=1` and `libgpiod` for `WITH_GPIO=1`.
 * Debian/Ubuntu: `sudo apt install build-essential libevent-dev libjpeg-dev libbsd-dev`.
 
 On Raspberry Pi you can build the program with OpenMAX IL. To do this pass option ```WITH_OMX=1``` to ```make```. To enable GPIO support install [libgpiod](https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about) and pass option ```WITH_GPIO=1```. If the compiler reports about a missing function ```pthread_get_name_np()``` (or similar), add option ```WITH_PTHREAD_NP=0``` (it's enabled by default). For the similar error with ```setproctitle()``` add option ```WITH_SETPROCTITLE=0```.

--- a/README.ru.md
+++ b/README.ru.md
@@ -34,10 +34,10 @@
 
 -----
 # Сборка
-Для сборки вам понадобятся ```make```, ```gcc```, ```libevent``` с поддержкой ```pthreads```, ```libjpeg8```/```libjpeg-turbo``` и ```libbsd``` (только для Linux).
+Для сборки вам понадобятся ```make```, ```gcc```, ```libevent``` с поддержкой ```pthreads```, ```libjpeg9```/```libjpeg-turbo``` и ```libbsd``` (только для Linux).
 
 * Arch: `sudo pacman -S libevent libjpeg-turbo libutil-linux libbsd`.
-* Raspbian: `sudo apt install libevent-dev libjpeg8-dev libbsd-dev`.  Добавьте `libraspberrypi-dev` для сборки с `WITH_OMX=1` и `libgpiod` для `WITH_GPIO=1`.
+* Raspbian: `sudo apt install libevent-dev libjpeg9-dev libbsd-dev`.  Добавьте `libraspberrypi-dev` для сборки с `WITH_OMX=1` и `libgpiod` для `WITH_GPIO=1`.
 * Debian/Ubuntu: `sudo apt install build-essential libevent-dev libjpeg-dev libbsd-dev`.
 
 На Raspberry Pi программу можно собрать с поддержкой OpenMAX IL. Для этого передайте ```make``` параметр ```WITH_OMX=1```. Для включения сборки с поддержкой GPIO установите [libgpiod](https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about) и добавьте параметр ```WITH_GPIO=1```. Если при сборке компилятор ругается на отсутствие функции ```pthread_get_name_np()``` или другой подобной, добавьте параметр ```WITH_PTHREAD_NP=0``` (по умолчанию он включен). При аналогичной ошибке с функцией ```setproctitle()``` добавьте параметр ```WITH_SETPROCTITLE=0```.

--- a/pkg/docker/Dockerfile.arm.cross
+++ b/pkg/docker/Dockerfile.arm.cross
@@ -5,7 +5,7 @@ RUN ["cross-build-start"]
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		gcc \
-		libjpeg8-dev \
+		libjpeg9-dev \
 		libbsd-dev \
 		libraspberrypi-dev \
 		libgpiod-dev \
@@ -24,7 +24,7 @@ RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		libevent-2.1 \
 		libevent-pthreads-2.1-6 \
-		libjpeg8 \
+		libjpeg9 \
 		libbsd0 \
 		libgpiod2 \
 	&& rm -rf /var/lib/apt/lists/*

--- a/pkg/docker/Dockerfile.arm.native
+++ b/pkg/docker/Dockerfile.arm.native
@@ -3,7 +3,7 @@ FROM balenalib/raspberrypi3-debian:build as build
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		gcc \
-		libjpeg8-dev \
+		libjpeg9-dev \
 		libbsd-dev \
 		libraspberrypi-dev \
 		libgpiod-dev \
@@ -19,7 +19,7 @@ RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		libevent-2.1 \
 		libevent-pthreads-2.1-6 \
-		libjpeg8 \
+		libjpeg9 \
 		libbsd0 \
 		libgpiod2 \
 	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The latest Raspbian build (2021-10-30-raspios-bullseye-armhf-lite) is based on Debian 11 (bullseye) which doesn't have an apt package for libjpeg8-dev. libjpeg9-dev works on both Debian 10 (buster) and Debian 11 (bullseye), so this change updates the libjpeg8 dependencies to libjpeg9.

Build output on Raspbian buster: https://gist.github.com/mtlynch/629c9fdf0c704a53077a6512963b4e2a#file-2021-05-07-raspios-buster-armhf-lite-img-txt
Build output on Raspbian bullseye: https://gist.github.com/mtlynch/629c9fdf0c704a53077a6512963b4e2a#file-2021-10-30-raspios-bullseye-armhf-lite-img-txt