### PR TITLE
Add a Nix Flake as a build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ vgcore.*
 *.pkg.tar.xz
 *.pkg.tar.zst
 *.tar.gz
+*result*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1641593416,
+        "narHash": "sha256-Vn/vqQtYnVuZlbGGO0gSzLjmtFwb6OPvakwyoG1D/MY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "36480448d470bf41bb21267cf9062a1542c4a95f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-21.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,148 @@
+{
+  description = "µStreamer - Lightweight and fast MJPG-HTTP streamer";
+
+  # Nixpkgs / NixOS version to use.
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-21.11";
+
+  outputs = { self, nixpkgs }:
+    let
+      version = builtins.substring 0 8 self.lastModifiedDate;
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; overlays = [ self.overlay ]; });
+    in
+{
+      overlay = final: prev: {
+        ustreamer = with final; stdenv.mkDerivation rec {
+          name = "ustreamer-${version}";
+          src = self;
+          buildInputs = [ libbsd libevent libjpeg ];
+          installPhase = ''
+            mkdir -p $out/bin
+            cp ustreamer $out/bin/
+          '';
+          meta = with lib; {
+            homepage = "https://github.com/pikvm/ustreamer";
+            description = "Lightweight and fast MJPG-HTTP streamer";
+            longDescription = ''
+              µStreamer is a lightweight and very quick server to stream MJPG video from
+              any V4L2 device to the net. All new browsers have native support of this
+              video format, as well as most video players such as mplayer, VLC etc.
+              µStreamer is a part of the Pi-KVM project designed to stream VGA and HDMI
+              screencast hardware data with the highest resolution and FPS possible.
+            '';
+            license = licenses.gpl3Plus;
+            platforms = platforms.linux;
+          };
+        };
+
+      };
+
+      packages = forAllSystems (system:
+        {
+          inherit (nixpkgsFor.${system}) ustreamer;
+        });
+
+      defaultPackage = forAllSystems (system: self.packages.${system}.ustreamer);
+
+      nixosModules.ustreamer =
+        { pkgs, ... }:
+        {
+          nixpkgs.overlays = [ self.overlay ];
+          environment.systemPackages = [ pkgs.ustreamer ];
+          networking.firewall.enable = false;
+          systemd.services.ustreamer = {
+            description = "ustreamer service";
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig = {
+              DynamicUser = true;
+              ExecStart = "${pkgs.ustreamer}/bin/ustreamer --host=0.0.0.0 --port 8000 --device /dev/video9 --device-timeout=8";
+              PrivateTmp = true;
+              BindReadOnlyPaths = "/dev/video9";
+              SupplementaryGroups = [
+                "video"
+              ];
+              Restart = "always";
+            };
+          };
+        };
+
+      # Tests run by 'nix flake check' and by Hydra.
+      checks = forAllSystems
+        (system:
+          with nixpkgsFor.${system};
+
+          lib.optionalAttrs stdenv.isLinux {
+            # A VM test of the NixOS module.
+            vmTest =
+              with import (nixpkgs + "/nixos/lib/testing-python.nix") {
+                inherit system;
+              };
+
+              makeTest {
+                nodes = {
+                  client = { ... }: {
+                    environment.systemPackages = [ pkgs.curl ];
+                  };
+                  camera = { config, ... }:
+                    let
+                      configFile = pkgs.writeText "akvcam-configFile" ''
+                        [Cameras]
+                        cameras/size = 2
+
+                        cameras/1/type = output
+                        cameras/1/mode = mmap, userptr, rw
+                        cameras/1/description = Virtual Camera (output device)
+                        cameras/1/formats = 2
+                        cameras/1/videonr = 7
+
+                        cameras/2/type = capture
+                        cameras/2/mode = mmap, rw
+                        cameras/2/description = Virtual Camera
+                        cameras/2/formats = 1, 2
+                        cameras/2/videonr = 9
+
+                        [Connections]
+                        connections/size = 1
+                        connections/1/connection = 1:2
+
+                        [Formats]
+                        formats/size = 2
+
+                        formats/1/format = YUY2
+                        formats/1/width = 640
+                        formats/1/height = 480
+                        formats/1/fps = 30
+
+                        formats/2/format = RGB24, YUY2
+                        formats/2/width = 640
+                        formats/2/height = 480
+                        formats/2/fps = 20/1, 15/2
+                      '';
+                    in
+                    {
+                      imports = [ self.nixosModules.ustreamer ];
+                      boot.extraModulePackages = [ config.boot.kernelPackages.akvcam ];
+                      boot.kernelModules = [ "akvcam" ];
+                      boot.extraModprobeConfig = ''
+                        options akvcam config_file=${configFile}
+                      '';
+                    };
+                };
+
+                testScript =
+                  ''
+                    start_all()
+
+                    camera.wait_for_unit("ustreamer.service")
+                    camera.wait_for_open_port("8000")
+
+                    client.wait_for_unit("multi-user.target")
+                    client.succeed("curl http://camera:8000")
+                  '';
+              };
+          }
+        );
+
+    };
+}


### PR DESCRIPTION
This adds a Nix flake which provides many outputs that can be built with
`nix build`:

I've also added a NixOS VM test for this software which creates two QEMU virtual machines, one named client` and another `camera`. The test then:
1. Creates an [akvcam](https://github.com/webcamoid/akvcam/) device
2. Uses ustreamer in a systemd service on the virtual akvcam device
3. Has a client run `curl` on the `camera` virtual machine, which returns a result from the ustreamer service.

This test can be ran by running `nix build .#checks.x86_64-linux.vmTest -L`

```
 nix flake show
git+file:///home/matthew/git/ustreamer?ref=nix&rev=34a78997449bf0e9893dda3d51682c359f031fce
├───checks
│   ├───aarch64-linux
│   │   └───vmTest: derivation 'vm-test-run-unnamed'
│   └───x86_64-linux
│       └───vmTest: derivation 'vm-test-run-unnamed'
├───defaultPackage
│   ├───aarch64-linux: package 'ustreamer-20220109'
│   └───x86_64-linux: package 'ustreamer-20220109'
├───nixosModules
│   └───ustreamer: NixOS module
├───overlay: Nixpkgs overlay
└───packages
    ├───aarch64-linux
    │   └───ustreamer: package 'ustreamer-20220109'
    └───x86_64-linux
        └───ustreamer: package 'ustreamer-20220109'
```

Nix builds are reproducible and deterministic. They do not use the host's environment for any reason, as they are sandboxed. A build on my machine will result in the same hash on your machine, as on another machine every time, since all inputs are controlled. This is the goal, and it is successful at this in the majority of cases. As an example, there could be some exceptions with Java and reading system time, but issues like these are easily identified and worked around.

The Nix thesis can be read here:
https://edolstra.github.io/pubs/phd-thesis.pdf