### PR TITLE
readme: suggest adding `/opt/vc/lib/` to library search path on bullseye

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Without arguments, ```ustreamer``` will try to open ```/dev/video0``` with 640x4
 
 The recommended way of running µStreamer with [Auvidea B101](https://www.raspberrypi.org/forums/viewtopic.php?f=38&t=120702&start=400#p1339178) on Raspberry Pi:
 ```bash
+$ export LD_LIBRARY_PATH=/opt/vc/lib/ # on bullseye
 $ ./ustreamer \
     --format=uyvy \ # Device input format
     --encoder=omx \ # Hardware encoding with OpenMAX


### PR DESCRIPTION
On Raspberry Pi OS Bullseye:
```sh
$ make WITH_OMX=1
[...]
== LD ustreamer.bin
/usr/bin/ld: warning: libbrcmGLESv2.so, needed by /opt/vc/lib/libopenmaxil.so, not found (try using -rpath or -rpath-link)
/usr/bin/ld: warning: libbrcmEGL.so, needed by /opt/vc/lib/libopenmaxil.so, not found (try using -rpath or -rpath-link)
[...]
$ ./ustreamer --features
./ustreamer: error while loading shared libraries: libopenmaxil.so: cannot open shared object file: No such file or directory
$ LD_LIBRARY_PATH=/opt/vc/lib/ ./ustreamer --features
+ WITH_OMX
- WITH_GPIO
+ WITH_PTHREAD_NP
+ WITH_SETPROCTITLE
+ HAS_PDEATHSIG
```