### PR TITLE
Don't close evbuffer_add_file's file descriptor

### DIFF
--- a/src/ustreamer/http/server.c
+++ b/src/ustreamer/http/server.c
@@ -317,6 +317,7 @@ static void _http_callback_static(struct evhttp_request *request, void *v_server
 			goto not_found;
 		}
 
+		fd = -1;
 		ADD_HEADER("Content-Type", guess_mime_type(static_path));
 		evhttp_send_reply(request, HTTP_OK, "OK", buf);
 		goto cleanup;


### PR DESCRIPTION
evbuffer_add_file takes ownership for the file descriptor we pass
and manages closing it. Closing it ourselves will lead to the function
only being able to make very small transfers.

Signed-off-by: Russ Dill <russ.dill@gmail.com>