### PR TITLE
Expose supplied client key in state

### DIFF
--- a/src/ustreamer/http/server.c
+++ b/src/ustreamer/http/server.c
@@ -421,13 +421,14 @@ static void _http_callback_state(struct evhttp_request *request, void *v_server)
 	LIST_ITERATE(RUN(stream_clients), client, {
 		assert(evbuffer_add_printf(buf,
 			"\"%" PRIx64 "\": {\"fps\": %u, \"extra_headers\": %s, \"advance_headers\": %s,"
-			" \"dual_final_frames\": %s, \"zero_data\": %s}%s",
+			" \"dual_final_frames\": %s, \"zero_data\": %s, \"key\": %s}%s",
 			client->id,
 			client->fps,
 			bool_to_string(client->extra_headers),
 			bool_to_string(client->advance_headers),
 			bool_to_string(client->dual_final_frames),
 			bool_to_string(client->zero_data),
+			client->key != NULL ? client->key : "0",
 			(client->next ? ", " : "")
 		));
 	});


### PR DESCRIPTION
The client key and id is currently supplied in a cookie. This
provides a way for a client to determine it's id in order to match
it within the state response. However if cookies are disabled or
the source domain differs from the ustreamer domain the cookie will
not be set.

This provides an alternate way for a client to find the state
response associated with it's connection by including the client
provided key in the state response. If the client does not supply
a key, the value 0 is supplied.

Signed-off-by: Russ Dill <russ.dill@gmail.com>