### PR TITLE
Setup guide for H.264

### DIFF
--- a/docs/h264.md
+++ b/docs/h264.md
@@ -1,0 +1,125 @@
+# Guide to H.264 streaming
+
+By default, µStreamer outputs an [MJPEG stream](https://en.wikipedia.org/wiki/Motion_JPEG). MJPEG is a continuous series of single JPEG images which are “emitted” at a specific rate. While this is a relatively simple mechanism, it can also consume a lot of bandwidth.
+
+For enhanced efficiency, µStreamer can be wrapped into a [WebRTC](https://en.wikipedia.org/wiki/WebRTC) server, and configured to deliver a [H.264 video stream](https://en.wikipedia.org/wiki/Advanced_Video_Coding).
+
+This guide demonstrates the setup of the WebRTC server, and how everything can be wired together.
+
+## Components and Control Flow
+
+In addition to µStreamer itself, the following components are involved:
+
+- **Janus**: A general-purpose WebRTC server. Its purpose is to facilitate the WebRTC connection and communication, but it doesn’t know anything about µStreamer or any other media supplier.
+- **µStreamer plugin for Janus**: A plugin to link µStreamer and Janus, and that provides the video data via shared memory from µStreamer.
+- **Janus JavaScript-Client**: A frontend library for connecting to the Janus server, and to exchange commands and data with the µStreamer plugin.
+
+Here is a high-level overview of how the control flow:
+
+1. On the server, start the µStreamer service.
+1. Start the Janus WebRTC server with the µStreamer plugin.
+1. On the client, establish a connection to the Janus server.
+1. Ask the server to attach the µStreamer plugin and start the video stream.
+
+## Server Setup
+
+- TODO: Compile µStreamer and Janus plugin
+- TODO: Start up µStreamer and Janus
+
+## Client Connection
+
+As prerequisites, you need to provide two libraries:
+
+- [The WebRTC Adapter library](https://github.com/webrtchacks/adapter) (`webrtc-adapter.js`, version `8.1.1`)
+- [The JavaScript library of Janus Gateway](https://github.com/meetecho/janus-gateway) (`janus.js`, version `1.0.0`)
+
+The only HTML we need is a `<video>` element for displaying the H.264 video stream.
+
+The control flow is this:
+
+1. Initiate the Janus client library.
+1. Establish a connection to the Janus server.
+1. Ask the server to attach the µStreamer plugin.
+1. On success, this returns a handle through which we can send commands to the µStreamer plugin directly. The responses are processed via the callbacks, e.g. `onmessage` callback for general messages, or `onremotetrack` for the video stream.
+1. Send a `watch` command to the µStreamer plugin. This initiates the H.264 stream in the plugin itself. For the very first call after starting the plugin, this doesn’t immediately succeed. It takes a few seconds until the stream becomes available. Therefore, we have to retry the command, until the plugin indicates that it’s ready by providing us with the `jsepOffer` parameter.
+1. With that in place, we can send a `start` command to the µStreamer plugin, which will make it begin streaming the H.264 video signal.
+1. Once the video data starts to arrive on the client, the `onremotetrack` callback is invoked. The received `track` object can be attached to the `<video>` element, which eventually displays the video on the screen.
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>µStreamer H.264 demo</title>
+  <script src="webrtc-adapter.js"></script>
+  <script src="janus.js"></script>
+  <style>
+    video {
+      height: 100%;
+      width: 100%;
+      object-fit: contain;
+    }
+  </style>
+</head>
+<body>
+  <video id="webrtc-output" autoplay playsinline muted></video>
+  <script type="text/javascript">
+    const videoElement = document.getElementById("webrtc-output");
+
+    // Initialize Janus library.
+    Janus.init({
+       debug: true, // For console logs in the browser.
+       dependencies: Janus.useDefaultDependencies(),
+    });
+
+    // Create Janus client.
+    const janus = new Janus({
+      server: 'ws://raspberrypi/janus/ws', // Replace this with your URL.
+      success: attachJanusPlugin,
+      error: console.error,
+    });
+
+    let janusPluginHandle = null;
+
+    function attachJanusPlugin() {
+      janus.attach({
+        plugin: "janus.plugin.ustreamer",
+        success: function (pluginHandle) {
+          janusPluginHandle = pluginHandle;
+          janusPluginHandle.send({ message: { request: "watch" } });
+        },
+        error: console.error,
+        onmessage: function (msg, jsepOffer) {
+          if (msg.error_code === 503) {
+            janusPluginHandle.send({ message: { request: "watch" } });
+            return;
+          }
+          if (jsepOffer) {
+            janusPluginHandle.createAnswer({
+              jsep: jsepOffer,
+              media: { audioSend: false, videoSend: false, data: false },
+              success: function (jsepAnswer) {
+                janusPluginHandle.send({
+                  message: { request: "start" },
+                  jsep: jsepAnswer,
+                });
+              },
+              error: console.error,
+            });
+          }
+        },
+        onremotetrack: function (track, mid, added) {
+          if (!added) {
+            videoElement.srcObject = null;
+            return;
+          }
+          const stream = new MediaStream();
+          stream.addTrack(track.clone());
+          videoElement.srcObject = stream;
+        },
+      });
+    }
+  </script>
+</body>
+</html>
+```


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/ustreamer/issues/1.

I’m just sharing this as rough WIP right now. A few notes as of 2022-04-04:

- The phrasing is not final yet.
- On a high-level, I wanted to divide the document into 4 sections: 1) a quick primer on the motivation, 2) a high-level overview of the involved components and how they play together, 3) the backend setup (not started yet), 4) the frontend setup.
- The HTML page is functional. I think it makes sense to keep the JS commentary relatively minimal, and provide the context in a separate description. The technical details are not all 100% accurate yet, I still need to read up on a few things in order to clarify this more.
- I’m not sure what the best way is to provide the libraries. I’ve just linked to the respective Github projects, but it’s still up to the user to find them there. I’d suppose this might be okay, though, since the audience are developers themselves, so they should know how to find a library.
- I haven’t figured out how to stop the video stream yet. I.e., I’m able to successfully send a `stop` request to the Janus plugin, but that doesn’t stop the media stream.
- I have found [the solution to fix the cold start behaviour](https://github.com/tiny-pilot/tinypilot/issues/948#issuecomment-1087923465), which is checking for the `503` error code and then retrying. (The retry should probably be throttled, though.)

@mtlynch How much do we want to go into detail about WebRTC in general? Shall we assume that people are sufficiently familiar with it, or shall we provide more context around the control flow?