### PR TITLE
Assign stream index on outgoing RTP packets

### DIFF
--- a/janus/src/client.c
+++ b/janus/src/client.c
@@ -102,6 +102,9 @@ static void *_common_thread(void *v_client, bool video) {
 				packet.video = rtp->video;
 				packet.buffer = (char *)rtp->datagram;
 				packet.length = rtp->used;
+				// The uStreamer Janus plugin places video in stream index 0 and audio
+				// (if available) in stream index 1.
+				packet.mindex = (rtp->video ? 0 : 1);
 				janus_plugin_rtp_extensions_reset(&packet.extensions);
 				// FIXME: Это очень эффективный способ уменьшить задержку, но WebRTC стек в хроме и фоксе
 				// слишком корявый, чтобы обработать это, из-за чего на кейфреймах начинаются заикания.

--- a/janus/src/client.c
+++ b/janus/src/client.c
@@ -102,9 +102,11 @@ static void *_common_thread(void *v_client, bool video) {
 				packet.video = rtp->video;
 				packet.buffer = (char *)rtp->datagram;
 				packet.length = rtp->used;
+#if JANUS_PLUGIN_API_VERSION >= 100
 				// The uStreamer Janus plugin places video in stream index 0 and audio
 				// (if available) in stream index 1.
 				packet.mindex = (rtp->video ? 0 : 1);
+#endif
 				janus_plugin_rtp_extensions_reset(&packet.extensions);
 				// FIXME: Это очень эффективный способ уменьшить задержку, но WebRTC стек в хроме и фоксе
 				// слишком корявый, чтобы обработать это, из-за чего на кейфреймах начинаются заикания.

--- a/janus/src/plugin.c
+++ b/janus/src/plugin.c
@@ -435,7 +435,9 @@ static struct janus_plugin_result *_plugin_handle_message(
 				"s=PiKVM uStreamer" RN
 				"t=0 0" RN
 				"%s%s",
-				us_get_now_id() >> 1, audio_sdp, video_sdp
+				// Place video SDP before audio SDP so that the video and audio streams
+				// have predictable indices, even if audio is not available.
+				us_get_now_id() >> 1, video_sdp, audio_sdp
 			);
 			free(audio_sdp);
 			free(video_sdp);

--- a/janus/src/plugin.c
+++ b/janus/src/plugin.c
@@ -435,9 +435,14 @@ static struct janus_plugin_result *_plugin_handle_message(
 				"s=PiKVM uStreamer" RN
 				"t=0 0" RN
 				"%s%s",
+#if JANUS_PLUGIN_API_VERSION >= 100
 				// Place video SDP before audio SDP so that the video and audio streams
 				// have predictable indices, even if audio is not available.
 				us_get_now_id() >> 1, video_sdp, audio_sdp
+#else
+				// For versions of Janus prior to 1.x, place the audio SDP first.
+				us_get_now_id() >> 1, audio_sdp, video_sdp
+#endif
 			);
 			free(audio_sdp);
 			free(video_sdp);


### PR DESCRIPTION
This change populates the mindex field of the janus janus_plugin_rtcp struct (see https://janus.conf.meetecho.com/docs/structjanus__plugin__rtcp.html#a5a3ef3ddd4a18e0245b89a703849e2f7). The change sets mindex to 0 for a video stream and 1 for an audio stream.

Without this fix, we observed the browser fail to decode video+audio streams because it would detect sequence number reuse since the video and audio streams had the same stream index.

This change also adjusts the ordering of SDPs in janus/src/plugin.c so that the video stream always appears first. We base this decision on the assumption that uStreamer supports video-only streams and video+audio streams, but never audio-only streams. With this assumption, placing the video SDP first means the video stream will always have index 0, and the audio stream will always have index 1.