### PR TITLE
Add (inline) favicon

### DIFF
--- a/src/ustreamer/data/index.html
+++ b/src/ustreamer/data/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 	<meta charset="utf-8" />
+	<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y=y='0.7em' font-size='140'>π</text></svg>">
 	<title>uStreamer</title>
 	<style>body {font-family: monospace;}</style>
 </head>


### PR DESCRIPTION
Adding a data URI favicon avoids having the browser send an extra HTTP request for `/favicon.ico` - which is met with HTTP 404 anyway.

P.S. Instead of using the Unicode Pi emoji one could of course also turn the PNG favicon from pikvm.org into a data URI.