### PR TITLE
Add audio streaming support for generic PCM devices.

### DIFF
--- a/janus/src/audio.h
+++ b/janus/src/audio.h
@@ -65,7 +65,7 @@ typedef struct {
 
 bool us_audio_probe(const char *name);
 
-us_audio_s *us_audio_init(const char *name, unsigned pcm_hz);
+us_audio_s *us_audio_init(const char *name, unsigned pcm_hz, unsigned pcm_channels);
 void us_audio_destroy(us_audio_s *audio);
 
 int us_audio_get_encoded(us_audio_s *audio, uint8_t *data, size_t *size, uint64_t *pts);

--- a/janus/src/config.c
+++ b/janus/src/config.c
@@ -53,8 +53,21 @@ us_config_s *us_config_init(const char *config_dir_path) {
 	}
 	if ((config->audio_dev_name = _get_value(jcfg, "audio", "device")) != NULL) {
 		if ((config->tc358743_dev_path = _get_value(jcfg, "audio", "tc358743")) == NULL) {
-			US_JLOG_INFO("config", "Missing config value: audio.tc358743");
-			goto error;
+			if((config->pcm_path = _get_value(jcfg, "audio", "pcm_path")) == NULL) {
+				US_JLOG_INFO("config", "Missing config value: audio.tc358743 OR audio.pcm_path");
+				goto error;
+			}
+			else {
+				if ((config->pcm_sampling_rate = _get_value(jcfg, "audio", "pcm_sampling_rate")) == NULL) {
+					config->pcm_sampling_rate = "44100";
+				}
+				US_JLOG_INFO("config", "PCM sample rate set to %sHz", config->pcm_sampling_rate);
+
+				if ((config->pcm_channels = _get_value(jcfg, "audio", "pcm_channels")) == NULL) {
+					config->pcm_channels = "1";
+				}
+				US_JLOG_INFO("config", "Number of PCM channels set to %s", config->pcm_channels);
+			}
 		}
 	}
 

--- a/janus/src/config.h
+++ b/janus/src/config.h
@@ -39,6 +39,9 @@ typedef struct {
 
 	char	*audio_dev_name;
 	char	*tc358743_dev_path;
+	char	*pcm_path;
+	char	*pcm_sampling_rate;
+	char	*pcm_channels;
 } us_config_s;
 
 


### PR DESCRIPTION
* Allow generic PCM devices to stream audio from ALSA via piKVM
* New config parameters in janus.plugin.ustreamer.jcfg:
  * pcm_path: Path in /dev/snd/ to PCM device
  * pcm_sampling_rate: Sampling rate
  * pcm_channels: Number of PCM channels