### PR TITLE
Discard truncated JPEG frames

### DIFF
--- a/src/ustreamer/device.h
+++ b/src/ustreamer/device.h
@@ -75,18 +75,26 @@ typedef struct {
 } us_hw_buffer_s;
 
 typedef struct {
-	int				fd;
-	unsigned		width;
-	unsigned		height;
-	unsigned		format;
-	unsigned		stride;
-	unsigned		hw_fps;
-	unsigned		jpeg_quality;
-	size_t			raw_size;
-	unsigned		n_bufs;
-	us_hw_buffer_s	*hw_bufs;
-	bool			capturing;
-	bool			persistent_timeout_reported;
+	uint64_t captured_frames;
+	uint64_t invalid_frames;
+	uint64_t skipped_frames;
+	uint64_t valid_frames;
+} us_device_stats_s;
+
+typedef struct {
+	int					fd;
+	unsigned			width;
+	unsigned			height;
+	unsigned			format;
+	unsigned			stride;
+	unsigned			hw_fps;
+	unsigned			jpeg_quality;
+	size_t				raw_size;
+	unsigned			n_bufs;
+	us_hw_buffer_s		*hw_bufs;
+	bool				capturing;
+	bool				persistent_timeout_reported;
+	us_device_stats_s	stats;
 } us_device_runtime_s;
 
 typedef enum {

--- a/src/ustreamer/http/server.c
+++ b/src/ustreamer/http/server.c
@@ -453,13 +453,17 @@ static void _http_callback_state(struct evhttp_request *request, void *v_server)
 
 	_A_EVBUFFER_ADD_PRINTF(buf,
 		" \"source\": {\"resolution\": {\"width\": %u, \"height\": %u},"
-		" \"online\": %s, \"desired_fps\": %u, \"captured_fps\": %u},"
+		" \"online\": %s, \"desired_fps\": %u, \"captured_fps\": %u,"
+		" \"captured_frames\": %lu, \"invalid_frames\": %lu, \"skipped_frames\": %lu},"
 		" \"stream\": {\"queued_fps\": %u, \"clients\": %u, \"clients_stat\": {",
 		(server->fake_width ? server->fake_width : _EX(frame->width)),
 		(server->fake_height ? server->fake_height : _EX(frame->height)),
 		us_bool_to_string(_EX(frame->online)),
 		_STREAM(dev->desired_fps),
 		_EX(captured_fps),
+		_STREAM(dev->run->stats.captured_frames),
+		_STREAM(dev->run->stats.invalid_frames),
+		_STREAM(dev->run->stats.skipped_frames),
 		_EX(queued_fps),
 		_RUN(stream_clients_count)
 	);
@@ -645,7 +649,7 @@ static void _http_callback_stream_write(struct bufferevent *buf_event, void *v_c
 
 	if (client->need_initial) {
 		_A_EVBUFFER_ADD_PRINTF(buf, "HTTP/1.0 200 OK" RN);
-		
+
 		if (client->server->allow_origin[0] != '\0') {
 			const char *const cors_headers = _http_get_header(client->request, "Access-Control-Request-Headers");
 			const char *const cors_method = _http_get_header(client->request, "Access-Control-Request-Method");
@@ -653,7 +657,7 @@ static void _http_callback_stream_write(struct bufferevent *buf_event, void *v_c
 			_A_EVBUFFER_ADD_PRINTF(buf,
 				"Access-Control-Allow-Origin: %s" RN
 				"Access-Control-Allow-Credentials: true" RN,
-				client->server->allow_origin				
+				client->server->allow_origin
 			);
 			if (cors_headers != NULL) {
 				_A_EVBUFFER_ADD_PRINTF(buf, "Access-Control-Allow-Headers: %s" RN, cors_headers);


### PR DESCRIPTION
Hello! This patch works around an issue encountered with [ELP-USB100W03M](https://www.webcamerausb.com/elp-10mp-free-driver-usb20-ov9712-cmos-sensor-hd-mjpeg-web-camera-board-720p-36mm-lens-p-116.html) cameras where they send a vast amount of invalid JPEGs when capturing their MJPEG streams. These bad frames account for about 87% of captured frames and cause issues for browsers and downstream applications.

This patch adds `_validate_frame` which combines the existing small frame check with the new truncated JPEG check. `us_device_grab_buffer` has been reworked to use `_validate_frame` to extract the **most recent** valid frame from the stream. Previously, it would skip over potentially valid frames if the most recent frame from the device is invalid.

I'm happy to make changes to get this patch merged, but I understand if this edge case is a bit too niche for inclusion. Thanks!