### PR TITLE
Multi Planar device support

### DIFF
--- a/src/libs/frame.c
+++ b/src/libs/frame.c
@@ -75,6 +75,7 @@ unsigned us_frame_get_padding(const us_frame_s *frame) {
 		case V4L2_PIX_FMT_YUYV:
 		case V4L2_PIX_FMT_UYVY:
 		case V4L2_PIX_FMT_RGB565: bytes_per_pixel = 2; break;
+		case V4L2_PIX_FMT_BGR24:
 		case V4L2_PIX_FMT_RGB24: bytes_per_pixel = 3; break;
 		// case V4L2_PIX_FMT_H264:
 		case V4L2_PIX_FMT_MJPEG:

--- a/src/ustreamer/device.c
+++ b/src/ustreamer/device.c
@@ -345,6 +345,9 @@ int us_device_grab_buffer(us_device_s *dev, us_hw_buffer_s **hw) {
 			}
 			GRABBED(new) = true;
 
+			if (dev->capture_type == V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE) 
+				new.bytesused = new.m.planes[0].bytesused;
+
 			broken = !_device_is_buffer_valid(dev, &new, FRAME_DATA(new));
 			if (broken) {
 				US_LOG_DEBUG("Releasing device buffer=%u (broken frame) ...", new.index);
@@ -370,8 +373,6 @@ int us_device_grab_buffer(us_device_s *dev, us_hw_buffer_s **hw) {
 #			undef FRAME_DATA
 
 			memcpy(&buf, &new, sizeof(struct v4l2_buffer));
-			if (dev->capture_type == V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE) 
-				buf.bytesused = buf.m.planes[0].bytesused;
 
 			buf_got = true;
 

--- a/src/ustreamer/device.c
+++ b/src/ustreamer/device.c
@@ -349,7 +349,7 @@ int us_device_grab_buffer(us_device_s *dev, us_hw_buffer_s **hw) {
 		new.type = dev->capture_type;
 		new.memory = dev->io_method;
 		if (dev->capture_type == V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE) {
-			new.length = 1;
+			new.length = VIDEO_MAX_PLANES;
 			new.m.planes = planes;
 		}
 		

--- a/src/ustreamer/device.h
+++ b/src/ustreamer/device.h
@@ -61,7 +61,7 @@
 #define US_STANDARDS_STR		"PAL, NTSC, SECAM"
 
 #define US_FORMAT_UNKNOWN		-1
-#define US_FORMATS_STR			"YUYV, UYVY, RGB565, RGB24, MJPEG, JPEG"
+#define US_FORMATS_STR			"YUYV, UYVY, RGB565, RGB24, BGR24, MJPEG, JPEG"
 
 #define US_IO_METHOD_UNKNOWN	-1
 #define US_IO_METHODS_STR		"MMAP, USERPTR"
@@ -126,6 +126,7 @@ typedef struct {
 	unsigned			jpeg_quality;
 	v4l2_std_id			standard;
 	enum v4l2_memory	io_method;
+	enum v4l2_buf_type  capture_type;
 	bool				dv_timings;
 	unsigned			n_bufs;
 	unsigned			desired_fps;


### PR DESCRIPTION
Some devices doesn't have V4L2_BUF_TYPE_VIDEO_CAPTURE support, but they can be a multi planar devices and have a bit different api (V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE).
I have one of this devices NanoPC-T6 based on RK3588 SoC. One of the cool features of this device is [HDMI IN ](https://wiki.friendlyelec.com/wiki/index.php/NanoPC-T6#How_to_test_HDMI-IN) support.
Also Orange Pi 5 Plus, Radxa Rock 5B and other SBC on RK3588 should work with it too.

`v4l2-ctl --all` output:
```
Driver Info:
	Driver name      : rk_hdmirx
	Card type        : rk_hdmirx
	Bus info         : fdee0000.hdmirx-controller
	Driver version   : 5.10.160
	Capabilities     : 0x84201000
		Video Capture Multiplanar
		Streaming
		Extended Pix Format
		Device Capabilities
	Device Caps      : 0x04201000
		Video Capture Multiplanar
		Streaming
		Extended Pix Format
Priority: 2
DV timings:
	Active width: 1920
	Active height: 1080
	Total width: 2640
	Total height: 1125
	Frame format: progressive
	Polarities: -vsync -hsync
	Pixelclock: 148492000 Hz (50.00 frames per second)
	Horizontal frontporch: 528
	Horizontal sync: 44
	Horizontal backporch: 148
	Vertical frontporch: 4
	Vertical sync: 5
	Vertical backporch: 36
	Standards: 
	Flags: 
DV timings capabilities:
	Minimum Width: 640
	Maximum Width: 4096
	Minimum Height: 480
	Maximum Height: 2160
	Minimum PClock: 20000000
	Maximum PClock: 600000000
	Standards: CTA-861
	Capabilities: Interlaced, Progressive
Format Video Capture Multiplanar:
	Width/Height      : 1920/1080
	Pixel Format      : 'BGR3' (24-bit BGR 8-8-8)
	Field             : None
	Number of planes  : 1
	Flags             : premultiplied-alpha, 0x000000fe
	Colorspace        : sRGB
	Transfer Function : Unknown (0x000000b8)
	YCbCr/HSV Encoding: Unknown (0x000000ff)
	Quantization      : Limited Range
	Plane 0           :
	   Bytes per Line : 5760
	   Size Image     : 6220800

Digital Video Controls

                  power_present 0x00a00964 (bitmask): max=0x00000001 default=0x00000000 value=1 flags=read-only
```


`v4l2-ctl --list-formats-ext -d /dev/video0` output:
```
ioctl: VIDIOC_ENUM_FMT
	Type: Video Capture Multiplanar

	[0]: 'BGR3' (24-bit BGR 8-8-8)
	[1]: 'NV24' (Y/CbCr 4:4:4)
	[2]: 'NV16' (Y/CbCr 4:2:2)
	[3]: 'NV12' (Y/CbCr 4:2:0)
```

Device has 4 pixel formats: NV24, NV16, NV12, BGR3 (BGR24). By default it works in NV24 mode. Device has no any controls, you can't set pixel format or resolution or fps. 
To set device in BGR3 pixel format you have to use EDID. 
I tested it with this one EDID:
```
wget https://raw.githubusercontent.com/pikvm/kvmd/master/configs/kvmd/edid/v3-hdmi.hex -O /edid.hex
v4l2-ctl --device=/dev/video0 --set-edid=file=/edid.hex --fix-edid-checksums --info-edid
```
Lines above turn on BGR3 pixel format, which is much easier to work and convert.

Command:
```
./ustreamer -m BGR24 -f 30

- INFO  [339862.490      main] -- Starting PiKVM uStreamer 5.43 ...
-- INFO  [339862.490      main] -- Using internal blank placeholder
-- INFO  [339862.491      main] -- Listening HTTP on [127.0.0.1]:8080
-- INFO  [339862.491    stream] -- Using V4L2 device: /dev/video0
-- INFO  [339862.491    stream] -- Using desired FPS: 30
-- INFO  [339862.491      http] -- Starting HTTP eventloop ...
================================================================================
-- INFO  [339862.491    stream] -- Device fd=8 opened
-- ERROR [339862.491    stream] -- Requested resolution=640x480 is unavailable
-- INFO  [339862.491    stream] -- Using resolution: 1920x1080, size:6220800
-- INFO  [339862.491    stream] -- Using format: BGR24
-- INFO  [339862.491    stream] -- Querying HW FPS changing is not supported
-- INFO  [339862.491    stream] -- Using IO method: MMAP
-- INFO  [339862.500    stream] -- Requested 5 device buffers, got 5
-- INFO  [339862.500    stream] -- Capturing started
-- INFO  [339862.500    stream] -- Using JPEG quality: 80%
-- INFO  [339862.500    stream] -- Creating pool JPEG with 4 workers ...
-- INFO  [339862.500    stream] -- Capturing ...
```

Environment:
```
rk3588-XYZ-ubuntu-jammy-desktop-5.10-arm64-YYYYMMDD.img.gz | jammy | Ubuntu 22.04 with GNOME and Wayland with recommended software | 5.10.y

pi@NanoPC-T6:~$ uname -a
Linux NanoPC-T6 5.10.160 #194 SMP Thu Sep 7 15:19:51 CST 2023 aarch64 aarch64 aarch64 GNU/Linux
pi@NanoPC-T6:~$ cat /etc/debian_version 
bookworm/sid
```

Probably some devices can have multiple planes, with different pixel format(for example), i can't test it, so i hardcode plane count to 1 (e.g. index=0).

I am not a C/C++ developer, so let me know about mistakes.