### PR TITLE
gpio: add support for libgpiod 2.x

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -42,7 +42,7 @@ endef
 
 ifneq ($(call optbool,$(WITH_GPIO)),)
 _USTR_LIBS += -lgpiod
-override _CFLAGS += -DWITH_GPIO
+override _CFLAGS += -DWITH_GPIO $(shell pkg-config --atleast-version=2 libgpiod 2> /dev/null && echo -DHAVE_GPIOD2)
 _USTR_SRCS += $(shell ls ustreamer/gpio/*.c)
 endif
 

--- a/src/ustreamer/gpio/gpio.h
+++ b/src/ustreamer/gpio/gpio.h
@@ -39,7 +39,11 @@ typedef struct {
 	int					pin;
 	const char			*role;
 	char 				*consumer;
+#ifdef HAVE_GPIOD2
+	struct gpiod_line_request	*line;
+#else
 	struct gpiod_line	*line;
+#endif
 	bool				state;
 } us_gpio_output_s;
 


### PR DESCRIPTION
Add support for libgpiod >=2 which overhauled API (in parallel with support for libgpiod 1.x).

Tested on Raspberry Pi Zero 2 with libgpiod 2.1.