### PR TITLE
remove remainings of rpi vc paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,6 @@ PY ?= python3
 CFLAGS ?= -O3
 LDFLAGS ?=
 
-RPI_VC_HEADERS ?= /opt/vc/include
-RPI_VC_LIBS ?= /opt/vc/lib
-
 export
 
 _LINTERS_IMAGE ?= ustreamer-linters


### PR DESCRIPTION
accidently left after Makefile split and subsequently switching to v4l2 based encoding