### PR TITLE
docker: build images for armv6

### DIFF
--- a/.github/workflows/docker-alpine-image.yaml
+++ b/.github/workflows/docker-alpine-image.yaml
@@ -66,7 +66,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/arm64,linux/amd64,linux/arm/v7
+          platforms: linux/arm64,linux/amd64,linux/arm/v6,linux/arm/v7
           file: pkg/docker/Dockerfile.alpine
       -
         name: Push


### PR DESCRIPTION
Older Pis as well as the Pi Zero use armv6. 
This PR adds the `linux/arm/v6` platform to the container build so images can also be used on them.

-Markus
