### PR TITLE
adapt pacman 6.1 and lower version

### DIFF
--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -28,13 +28,6 @@ if [ -e /usr/include/janus/plugins/plugin.h ];then
 fi
 
 
-# LD does not link mmal with this option
-# This DOESN'T affect setup.py
-LDFLAGS="${LDFLAGS//,--as-needed,/,}"
-LDFLAGS="${LDFLAGS//-Wl,--as-needed /}"  # pacman 6.1
-export LDFLAGS="${LDFLAGS}"
-
-
 build() {
 	cd "$srcdir"
 	rm -rf $pkgname-build

--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -30,8 +30,9 @@ fi
 
 # LD does not link mmal with this option
 # This DOESN'T affect setup.py
-LDFLAGS="${LDFLAGS//--as-needed/}"
-export LDFLAGS="${LDFLAGS//,,/,}"
+LDFLAGS="${LDFLAGS//,--as-needed,/,}"
+LDFLAGS="${LDFLAGS//-Wl,--as-needed /}"  # pacman 6.1
+export LDFLAGS="${LDFLAGS}"
 
 
 build() {


### PR DESCRIPTION
pacman 6.1 change LDFLAGS

### previous /etc/makepkg.conf

```
LDFLAGS="-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now"
```

### current /etc/makepkg.conf

```
LDFLAGS="-Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now \
         -Wl,-z,pack-relative-relocs"
```

pass '-Wl, ' to ld, invoke link error...

