### PR TITLE
Fix crash on FreeBSD due to incorrect thr_self system call invocation

### DIFF
--- a/src/libs/threading.h
+++ b/src/libs/threading.h
@@ -113,7 +113,9 @@ INLINE void us_thread_get_name(char *name) { // Always required for logging
 #if defined(__linux__)
 		const pid_t tid = syscall(SYS_gettid);
 #elif defined(__FreeBSD__)
-		const pid_t tid = syscall(SYS_thr_self);
+		long id;
+		assert(!syscall(SYS_thr_self, &id));
+		const pid_t tid = id;
 #elif defined(__OpenBSD__)
 		const pid_t tid = syscall(SYS_getthrid);
 #elif defined(__NetBSD__)


### PR DESCRIPTION
The correct signature is:
int thr_self(long *id);

It was called as thr_self() which caused memory corruption.

----------

Alternatively, it can be called directly, without syscall, according to its manpage:
```
NAME
     thr_self – return thread identifier for the calling thread

LIBRARY
     Standard C Library (libc, -lc)

SYNOPSIS
     #include <sys/thr.h>

     int
     thr_self(long *id);
```

-------

Other *BSDs likely have the same problem.
