### PR TITLE
Add option which allows to handle truncated frames.

### DIFF
--- a/src/libs/capture.c
+++ b/src/libs/capture.c
@@ -544,8 +544,8 @@ bool _capture_is_buffer_valid(const us_capture_s *cap, const struct v4l2_buffer 
 		const u8 *const eoi_ptr = end_ptr - 2;
 		const u16 eoi_marker = (((u16)(eoi_ptr[0]) << 8) | eoi_ptr[1]);
 		if (eoi_marker != 0xFFD9 && eoi_marker != 0xD900 && eoi_marker != 0x0000) {
-			_LOG_DEBUG("Discarding truncated JPEG frame: eoi_marker=0x%04x, bytesused=%u", eoi_marker, buf->bytesused);
-			return false;
+			_LOG_DEBUG("Got truncated JPEG frame: eoi_marker=0x%04x, bytesused=%u", eoi_marker, buf->bytesused);
+			return cap->allow_truncated_frames;
 		}
 	}
 

--- a/src/libs/capture.h
+++ b/src/libs/capture.h
@@ -119,6 +119,7 @@ typedef struct {
 	uint				timeout;
 	us_controls_s 		ctl;
 	us_capture_runtime_s *run;
+    bool                allow_truncated_frames;
 } us_capture_s;
 
 

--- a/src/ustreamer/options.c
+++ b/src/ustreamer/options.c
@@ -56,6 +56,7 @@ enum _US_OPT_VALUES {
 
 	_O_HELP = 'h',
 	_O_VERSION = 'v',
+    _O_ALLOW_TRUNCATED_FRAMES = 'T',
 
 	// Longs only
 
@@ -237,6 +238,7 @@ static const struct option _LONG_OPTS[] = {
 	{"debug",					no_argument,		NULL,	_O_DEBUG},
 	{"force-log-colors",		no_argument,		NULL,	_O_FORCE_LOG_COLORS},
 	{"no-log-colors",			no_argument,		NULL,	_O_NO_LOG_COLORS},
+    {"allow-truncated-frames",	no_argument,		NULL,	_O_ALLOW_TRUNCATED_FRAMES},
 
 	{"help",					no_argument,		NULL,	_O_HELP},
 	{"version",					no_argument,		NULL,	_O_VERSION},
@@ -499,6 +501,7 @@ int options_parse(us_options_s *options, us_capture_s *cap, us_encoder_s *enc, u
 			case _O_DEBUG:				OPT_SET(us_g_log_level, US_LOG_LEVEL_DEBUG);
 			case _O_FORCE_LOG_COLORS:	OPT_SET(us_g_log_colored, true);
 			case _O_NO_LOG_COLORS:		OPT_SET(us_g_log_colored, false);
+            case _O_ALLOW_TRUNCATED_FRAMES:OPT_SET(cap->allow_truncated_frames, true);
 
 			case _O_HELP:		_help(stdout, cap, enc, stream, server); return 1;
 			case _O_VERSION:	puts(US_VERSION); return 1;


### PR DESCRIPTION
Extension of https://github.com/pikvm/ustreamer/commit/c96559e4ac3c89b756cde23eb08397ce0a4e4907. Some cheap Chinese cameras produce frames that are detected as 'broken'. However, they are later handled well.
Introduce an option that allows disable the check on demand.