### PR TITLE
Allow overriding pkg-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ MANPREFIX ?= $(PREFIX)/share/man
 
 CC ?= gcc
 PY ?= python3
+PKG_CONFIG ?= pkg-config
 CFLAGS ?= -O3
 LDFLAGS ?=
 
@@ -17,8 +18,8 @@ _LINTERS_IMAGE ?= ustreamer-linters
 
 
 # =====
-ifeq (__not_found__,$(shell which pkg-config 2>/dev/null || echo "__not_found__"))
-$(error "No pkg-config found in $(PATH)")
+ifeq (__not_found__,$(shell which $(PKG_CONFIG) 2>/dev/null || echo "__not_found__"))
+$(error "No $(PKG_CONFIG) found in $(PATH)")
 endif
 
 

--- a/janus/Makefile
+++ b/janus/Makefile
@@ -2,6 +2,7 @@ R_DESTDIR ?=
 PREFIX ?= /usr/local
 
 CC ?= gcc
+PKG_CONFIG ?= pkg-config
 CFLAGS ?= -O3
 LDFLAGS ?=
 
@@ -9,8 +10,8 @@ LDFLAGS ?=
 # =====
 _PLUGIN = libjanus_ustreamer.so
 
-_CFLAGS = -fPIC -MD -c -std=c17 -Wall -Wextra -D_GNU_SOURCE $(shell pkg-config --cflags glib-2.0) $(CFLAGS)
-_LDFLAGS = -shared -lm -pthread -lrt -ljansson -lopus -lasound -lspeexdsp $(shell pkg-config --libs glib-2.0) $(LDFLAGS)
+_CFLAGS = -fPIC -MD -c -std=c17 -Wall -Wextra -D_GNU_SOURCE $(shell $(PKG_CONFIG) --cflags glib-2.0) $(CFLAGS)
+_LDFLAGS = -shared -lm -pthread -lrt -ljansson -lopus -lasound -lspeexdsp $(shell $(PKG_CONFIG) --libs glib-2.0) $(LDFLAGS)
 
 _SRCS = $(shell ls src/uslibs/*.c src/*.c)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,6 +2,7 @@ R_DESTDIR ?=
 PREFIX ?= /usr/local
 
 CC ?= gcc
+PKG_CONFIG ?= pkg-config
 CFLAGS ?= -O3
 LDFLAGS ?=
 
@@ -51,7 +52,7 @@ endef
 
 
 ifneq ($(call optbool,$(WITH_GPIO)),)
-override _CFLAGS += -DWITH_GPIO $(shell pkg-config --atleast-version=2 libgpiod 2> /dev/null && echo -DHAVE_GPIOD2)
+override _CFLAGS += -DWITH_GPIO $(shell $(PKG_CONFIG) --atleast-version=2 libgpiod 2> /dev/null && echo -DHAVE_GPIOD2)
 override _USTR_LDFLAGS += -lgpiod
 override _USTR_SRCS += $(shell ls ustreamer/gpio/*.c)
 endif
@@ -83,10 +84,10 @@ WITH_V4P ?= 0
 ifneq ($(call optbool,$(WITH_V4P)),)
 override _TARGETS += $(_V4P)
 override _OBJS += $(_V4P_SRCS:%.c=$(_BUILD)/%.o)
-override _CFLAGS += -DWITH_V4P $(shell pkg-config --cflags libdrm)
-override _V4P_LDFLAGS += $(shell pkg-config --libs libdrm)
+override _CFLAGS += -DWITH_V4P $(shell $(PKG_CONFIG) --cflags libdrm)
+override _V4P_LDFLAGS += $(shell $(PKG_CONFIG) --libs libdrm)
 override _USTR_SRCS += $(shell ls libs/drm/*.c)
-override _USTR_LDFLAGS += $(shell pkg-config --libs libdrm)
+override _USTR_LDFLAGS += $(shell $(PKG_CONFIG) --libs libdrm)
 endif
 
 


### PR DESCRIPTION
This change allows overriding pkg-config for cross-compilation:

```
make CC=aarch64-unknown-linux-gnu-gcc PKG_CONFIG=aarch64-unknown-linux-gnu-pkg-config
```

Re-submission of #294.