### PR TITLE
Allow optional acap property - sampling_rate

### DIFF
--- a/janus/src/config.c
+++ b/janus/src/config.c
@@ -22,6 +22,7 @@
 
 #include "config.h"
 
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -36,6 +37,7 @@
 
 
 static char *_get_value(janus_config *jcfg, const char *section, const char *option);
+static uint _get_uint(janus_config *jcfg, const char *section, const char *option, bool def);
 // static bool _get_bool(janus_config *jcfg, const char *section, const char *option, bool def);
 
 
@@ -65,6 +67,7 @@ us_config_s *us_config_init(const char *config_dir_path) {
 			US_JLOG_INFO("config", "Missing config value: acap.tc358743");
 			goto error;
 		}
+		config->acap_sampling_rate = _get_uint(jcfg, "acap", "sampling_rate", 0);
 		if ((config->aplay_dev_name = _get_value(jcfg, "aplay", "device")) != NULL) {
 			char *path = _get_value(jcfg, "aplay", "check");
 			if (path != NULL) {
@@ -103,6 +106,20 @@ static char *_get_value(janus_config *jcfg, const char *section, const char *opt
 		return NULL;
 	}
 	return us_strdup(option_obj->value);
+}
+
+static uint _get_uint(janus_config *jcfg, const char *section, const char *option, bool def) {
+	char *const tmp = _get_value(jcfg, section, option);
+	uint value = def;
+	if (tmp != NULL) {
+		errno = 0;
+		value = (uint) strtoul(tmp, NULL, 10);
+		if (errno != 0) {
+			value = def;
+		}
+		free(tmp);
+	}
+	return value;
 }
 
 /*static bool _get_bool(janus_config *jcfg, const char *section, const char *option, bool def) {

--- a/janus/src/config.h
+++ b/janus/src/config.h
@@ -27,9 +27,11 @@ typedef struct {
 	char	*video_sink_name;
 
 	char	*acap_dev_name;
+    unsigned int    acap_sampling_rate;
 	char	*tc358743_dev_path;
 
 	char	*aplay_dev_name;
+
 } us_config_s;
 
 

--- a/janus/src/plugin.c
+++ b/janus/src/plugin.c
@@ -244,16 +244,18 @@ static void *_acap_thread(void *arg) {
 			continue;
 		}
 
-		uint hz = 0;
+		uint hz = _g_config->acap_sampling_rate;
 		us_acap_s *acap = NULL;
 
-		if (_check_tc358743_acap(&hz) < 0) {
+		US_ONCE({ US_JLOG_INFO("acap", "Configured acap_sampling_rate : %d", _g_config->acap_sampling_rate); });
+		if (hz == 0 && _check_tc358743_acap(&hz) < 0) {
 			goto close_acap;
 		}
 		if (hz == 0) {
 			US_ONCE({ US_JLOG_INFO("acap", "No audio presented from the host"); });
 			goto close_acap;
 		}
+
 		US_ONCE({ US_JLOG_INFO("acap", "Detected host audio"); });
 		if ((acap = us_acap_init(_g_config->acap_dev_name, hz)) == NULL) {
 			goto close_acap;
@@ -262,7 +264,7 @@ static void *_acap_thread(void *arg) {
 		once = 0;
 
 		while (!_STOP && _HAS_WATCHERS && _HAS_LISTENERS) {
-			if (_check_tc358743_acap(&hz) < 0 || acap->pcm_hz != hz) {
+			if (_g_config->acap_sampling_rate == 0 && (_check_tc358743_acap(&hz) < 0 || acap->pcm_hz != hz)) {
 				goto close_acap;
 			}
 			uz size = US_RTP_DATAGRAM_SIZE - US_RTP_HEADER_SIZE;


### PR DESCRIPTION
This is needed when using audio capture from a device other than tc358743 such as a UAC2 Capture device to have two way audio over USB

When sampling_rate is provided, janus plugin don't try to query tc358743