### PR TITLE
Janus: "Absolute Capture Time" RTP extension added for video

### DIFF
--- a/janus/src/client.c
+++ b/janus/src/client.c
@@ -205,6 +205,8 @@ static void *_video_or_acap_thread(void *v_client, bool video) {
 			}
 
 			if (rtp.video) {
+				packet.extensions.abs_capture_ts = rtp.grab_ntp_ts;
+
 				uint video_orient = atomic_load(&client->video_orient);
 				if (video_orient != 0) {
 					// The extension rotates the video clockwise, but want it counterclockwise.

--- a/janus/src/rtp.h
+++ b/janus/src/rtp.h
@@ -46,6 +46,7 @@ typedef struct {
 	u8		datagram[US_RTP_DATAGRAM_SIZE];
 	uz		used;
 	bool	zero_playout_delay;
+	u64		grab_ntp_ts;
 } us_rtp_s;
 
 typedef void (*us_rtp_callback_f)(const us_rtp_s *rtp);

--- a/janus/src/rtpv.c
+++ b/janus/src/rtpv.c
@@ -73,6 +73,7 @@ char *us_rtpv_make_sdp(us_rtpv_s *rtpv) {
 		"a=ssrc:%" PRIu32 " cname:ustreamer" RN
 		"a=extmap:1 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay" RN
 		"a=extmap:2 urn:3gpp:video-orientation" RN
+		"a=extmap:3/sendonly http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time" RN
 		"a=sendonly" RN,
 		pl, pl, pl, pl, pl, pl,
 		rtpv->rtp->ssrc
@@ -89,6 +90,8 @@ void us_rtpv_wrap(us_rtpv_s *rtpv, const us_frame_s *frame, bool zero_playout_de
 	assert(frame->format == V4L2_PIX_FMT_H264);
 
 	rtpv->rtp->zero_playout_delay = zero_playout_delay;
+	rtpv->rtp->grab_ntp_ts =
+		us_get_now_ntp() - (us_get_now_monotonic() - frame->grab_begin_ts) * NTP_TICKS_IN_SECOND;
 
 	const u32 pts = us_get_now_monotonic_u64() * 9 / 100; // PTS units are in 90 kHz
 	sz last_offset = -_PRE;

--- a/src/libs/tools.h
+++ b/src/libs/tools.h
@@ -85,6 +85,8 @@
 
 #define US_ONCE(...) US_ONCE_FOR(once, __LINE__, ##__VA_ARGS__)
 
+#define NTP_UNIX_TIME_DIFF 2208988800u // difference between Unix time and NTP time in seconds (1970 - 1900)
+#define NTP_TICKS_IN_SECOND 4294967296u // ticks per second in NTP time
 
 INLINE char *us_strdup(const char *str) {
 	char *const new = strdup(str);
@@ -139,6 +141,12 @@ INLINE u64 us_get_now_monotonic_u64(void) {
 	struct timespec ts;
 	US_A(!clock_gettime(CLOCK_MONOTONIC, &ts));
 	return (u64)(ts.tv_nsec / 1000) + (u64)ts.tv_sec * 1000000;
+}
+
+INLINE u64 us_get_now_ntp(void) {
+	struct timespec ts;
+	assert(!clock_gettime(CLOCK_REALTIME, &ts));
+	return (((u64)ts.tv_sec + NTP_UNIX_TIME_DIFF) << 32) + ((u64)ts.tv_nsec / 1000 * NTP_TICKS_IN_SECOND ) / 1000000;
 }
 
 INLINE u64 us_get_now_id(void) {


### PR DESCRIPTION
It can be useful to estimate Glass-to-Glass latency.