### PR TITLE
ustreamer: options: NULL-terminate the copy of `argv`

### DIFF
--- a/src/ustreamer/options.c
+++ b/src/ustreamer/options.c
@@ -300,10 +300,11 @@ us_options_s *us_options_init(uint argc, char *argv[]) {
 	opts->argc = argc;
 	opts->argv = argv;
 
-	US_CALLOC(opts->argv_copy, argc);
+	US_CALLOC(opts->argv_copy, argc + 1);
 	for (uint i = 0; i < argc; ++i) {
 		opts->argv_copy[i] = us_strdup(argv[i]);
 	}
+	opts->argv_copy[argc] = NULL;
 	return opts;
 }
 


### PR DESCRIPTION
According to N2176 of ISO/IEC 9899:2017 §5.1.2.2.1 ¶2:

> - argv[argc] shall be a null pointer.

Possibly fixes the segfault referenced in openwrt/packages#28472.