### PR TITLE
Increase default raw memsink size to support 4k video

### DIFF
--- a/src/libs/memsinksh.c
+++ b/src/libs/memsinksh.c
@@ -61,7 +61,7 @@ uz us_memsink_calculate_size(const char *obj) {
 		} else if (!strcasecmp(ptr, "h264")) {
 			return 2 * 1024 * 1024;
 		} else if (!strcasecmp(ptr, "raw")) {
-			return 1920 * 1200 * 3; // RGB
+			return 3840 * 2160 * 3; // RGB
 		}
 	}
 	return 0;

--- a/src/libs/memsinksh.h
+++ b/src/libs/memsinksh.h
@@ -27,7 +27,7 @@
 
 
 #define US_MEMSINK_MAGIC	((u64)0xCAFEBABECAFEBABE)
-#define US_MEMSINK_VERSION	((u32)7)
+#define US_MEMSINK_VERSION	((u32)8)
 
 
 typedef struct {


### PR DESCRIPTION
With this change, it's possible to use ustreamer to handle 4k HDMI input on RK3588-based boards (tested on Orange Pi 5+ and Radxa ROCK 5B+).

If you'd prefer this to be configurable instead, I'd appreciate some hints how to route relevant option into the function.