### PR TITLE
python: Makefile: use `python -m installer`; do not install while building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ apps:
 
 python:
 	$(MAKE) -C python
-	$(ECHO) ln -sf python/root/usr/lib/python*/site-packages/*.so .
+	$(ECHO) ln -sf python/build/lib.linux-*/*.so -t .
 
 
 janus:

--- a/python/Makefile
+++ b/python/Makefile
@@ -9,12 +9,11 @@ all: root
 root: $(shell find src -type f,l) setup.py
 	$(info == PY_BUILD ustreamer-*.so)
 	rm -rf root
-	$(ECHO) $(PY) -m build --skip-dependency-check --no-isolation
-	$(ECHO) $(PY) -m pip install dist/*.whl --ignore-installed --root=./root
+	$(ECHO) $(PY) -m build --wheel --skip-dependency-check --no-isolation
 
 
 install:
-	$(PY) -m pip install dist/*.whl --ignore-installed --prefix=$(PREFIX) --root=$(if $(R_DESTDIR),$(R_DESTDIR),/)
+	$(PY) -m installer --prefix=$(PREFIX) $(if $(R_DESTDIR),--destdir=$(R_DESTDIR),) dist/*.whl
 
 
 clean:


### PR DESCRIPTION
When building a Python wheel using `python -m build --wheel ...`,
temporary build files (including extension .so) are placed in ./build/...
from where they can be retrieved without having to install the just-built
wheel. Do both and get rid of `pip` invocations.
