### PR TITLE
cpu encoder: fix chroma row advance timing in YUV420/YVU420 planar path

### DIFF
--- a/src/ustreamer/encoders/cpu/encoder.c
+++ b/src/ustreamer/encoders/cpu/encoder.c
@@ -223,6 +223,11 @@ static void _jpeg_write_scanlines_yuv_planar(struct jpeg_compress_struct *jpeg, 
 	const u8 *chroma2_data = frame->data + luma_array_size + chroma_array_size;
 
 	while (jpeg->next_scanline < frame->height) {
+		if (jpeg->next_scanline > 0 && jpeg->next_scanline % 2 == 0) {
+			chroma1_data += (frame->width + padding) >> 1;
+			chroma2_data += (frame->width + padding) >> 1;
+		}
+
 		u8 *ptr = line_buf;
 
 		for (uint x = 0; x < frame->width; ++x) {
@@ -252,11 +257,6 @@ static void _jpeg_write_scanlines_yuv_planar(struct jpeg_compress_struct *jpeg, 
 		}
 
 		data += frame->width + padding;
-
-		if (jpeg->next_scanline > 0 && jpeg->next_scanline % 2 == 0) {
-			chroma1_data += (frame->width + padding) >> 1;
-			chroma2_data += (frame->width + padding) >> 1;
-		}
 
 		JSAMPROW scanlines[1] = {line_buf};
 		jpeg_write_scanlines(jpeg, scanlines, 1);


### PR DESCRIPTION
## What
`_jpeg_write_scanlines_yuv_planar()` in `src/ustreamer/encoders/cpu/encoder.c` (the software JPEG encoder path for `V4L2_PIX_FMT_YUV420` / `V4L2_PIX_FMT_YVU420` planar frames) advances the chroma row pointers (`chroma1_data`/`chroma2_data`) *after* building the current luma row from them, instead of before.

Concretely, for luma row `next_scanline`:
- row 0, 1: correctly read chroma row 0
- row 2: **should** read chroma row 1, but still reads chroma row 0 (the advance for `next_scanline == 2` only happens after this row is built)
- row 3: reads chroma row 1 (correct, because the advance already happened when building row 2)
- row 4: **should** read chroma row 2, but reads chroma row 1
- ...and so on for every even row >= 2

Net effect: every even luma row (>= 2) reads the previous chroma-row-pair's U/V samples instead of its own, producing wrong chroma placement for roughly half the frame's rows in this planar 4:2:0 encode path.

## Fix
Move the existing advance block to the top of the `while (jpeg->next_scanline < frame->height)` loop, before the per-pixel row-build loop, so it takes effect before the chroma pointers are read for that row instead of after. The condition and stride arithmetic are unchanged — only the position relative to the read moves.

## Verification
Not able to build against the real `libjpeg`/`linux/videodev2.h` headers in my environment, so I extracted the exact control flow of this function verbatim into a standalone harness (same advance condition, same position relative to the row-build and `jpeg_write_scanlines()`, with `jpeg_write_scanlines()` mocked to just increment `next_scanline`, and chroma memory tagged per-row so the row actually read is directly observable):

- 8-row / width-4 / padding-0 case: unpatched logic mismatches on rows 2, 4, 6; patched logic matches all 8 rows.
- Realistic 640x480 / padding-16 case: unpatched logic produces exactly 239 mismatches (= `HEIGHT/2 - 1`, i.e. every even row from 2 to 478); patched logic produces 0 mismatches.

This is a pure control-flow/pointer-timing defect independent of libjpeg's internals, so the extracted-logic reproduction fully demonstrates both the bug and the fix.
